### PR TITLE
Fix deploy python version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9.7
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.7'


### PR DESCRIPTION
Recently the actions default Python version changed from 3.9.7 to 3.10.0 causing the errors seen on https://github.com/ros-planning/moveit2_tutorials/runs/4024729243?check_suite_focus=true. This is an attempt to fix it.