### PR TITLE
[foxy] Fix htmlproof failures by force installing docutils 0.17.1

### DIFF
--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -10,6 +10,7 @@ gem update --system
 gem --version
 gem install html-proofer
 # Install ROS's version of sphinx
+pip install docutils==0.17.1
 pip install sphinx==1.8.5
 sphinx-build --version
 


### PR DESCRIPTION
docutils has been updated to version 0.18.0 2 days ago and was not compatible with htmlproofer script. This PR forces version 0.17.1 to fix our CI jobs.