### PR TITLE
Reordered code execution

### DIFF
--- a/doc/examples/motion_planning_api/src/motion_planning_api_tutorial.cpp
+++ b/doc/examples/motion_planning_api/src/motion_planning_api_tutorial.cpp
@@ -75,7 +75,7 @@ int main(int argc, char** argv)
   /* Create a RobotState and JointModelGroup to keep track of the current robot pose and planning group*/
   moveit::core::RobotStatePtr robot_state(new moveit::core::RobotState(robot_model));
   const moveit::core::JointModelGroup* joint_model_group = robot_state->getJointModelGroup(PLANNING_GROUP);
-  
+
   // We spin up a SingleThreadedExecutor for the current state monitor to get information
   // about the robot's state.
   rclcpp::executors::SingleThreadedExecutor executor;

--- a/doc/examples/motion_planning_api/src/motion_planning_api_tutorial.cpp
+++ b/doc/examples/motion_planning_api/src/motion_planning_api_tutorial.cpp
@@ -56,10 +56,6 @@ int main(int argc, char** argv)
   std::shared_ptr<rclcpp::Node> motion_planning_api_tutorial_node =
       rclcpp::Node::make_shared("motion_planning_api_tutorial", node_options);
 
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(motion_planning_api_tutorial_node);
-  std::thread([&executor]() { executor.spin(); }).detach();
-
   // BEGIN_TUTORIAL
   // Start
   // ^^^^^
@@ -79,6 +75,12 @@ int main(int argc, char** argv)
   /* Create a RobotState and JointModelGroup to keep track of the current robot pose and planning group*/
   moveit::core::RobotStatePtr robot_state(new moveit::core::RobotState(robot_model));
   const moveit::core::JointModelGroup* joint_model_group = robot_state->getJointModelGroup(PLANNING_GROUP);
+  
+  // We spin up a SingleThreadedExecutor for the current state monitor to get information
+  // about the robot's state.
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(motion_planning_api_tutorial_node);
+  std::thread([&executor]() { executor.spin(); }).detach();
 
   // Using the
   // :moveit_codedir:`RobotModel<moveit_core/robot_model/include/moveit/robot_model/robot_model.h>`,

--- a/doc/examples/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
+++ b/doc/examples/motion_planning_pipeline/src/motion_planning_pipeline_tutorial.cpp
@@ -56,10 +56,6 @@ int main(int argc, char** argv)
   node_options.automatically_declare_parameters_from_overrides(true);
   auto node = rclcpp::Node::make_shared("motion_planning_pipeline_tutorial", node_options);
 
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(node);
-  std::thread([&executor]() { executor.spin(); }).detach();
-
   // BEGIN_TUTORIAL
   // Start
   // ^^^^^
@@ -104,6 +100,12 @@ int main(int argc, char** argv)
   /* Create a JointModelGroup to keep track of the current robot pose and planning group. The Joint Model
      group is useful for dealing with one set of joints at a time such as a left arm or a end effector */
   const moveit::core::JointModelGroup* joint_model_group = robot_state->getJointModelGroup("panda_arm");
+
+  // We spin up a SingleThreadedExecutor for the current state monitor to get information
+  // about the robot's state.
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  std::thread([&executor]() { executor.spin(); }).detach();
 
   // We can now setup the PlanningPipeline object, which will use the ROS parameter server
   // to determine the set of request adapters and the planning plugin to use

--- a/doc/examples/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/examples/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
   rclcpp::NodeOptions node_options;
   node_options.automatically_declare_parameters_from_overrides(true);
   auto move_group_node = rclcpp::Node::make_shared("move_group_interface_tutorial", node_options);
-  
+
   // BEGIN_TUTORIAL
   //
   // Setup
@@ -71,7 +71,7 @@ int main(int argc, char** argv)
   // :moveit_codedir:`MoveGroupInterface<moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h>`
   // class can be easily set up using just the name of the planning group you would like to control and plan for.
   moveit::planning_interface::MoveGroupInterface move_group(move_group_node, PLANNING_GROUP);
-  
+
   // We spin up a SingleThreadedExecutor for the current state monitor to get information
   // about the robot's state.
   rclcpp::executors::SingleThreadedExecutor executor;

--- a/doc/examples/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/examples/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -56,13 +56,7 @@ int main(int argc, char** argv)
   rclcpp::NodeOptions node_options;
   node_options.automatically_declare_parameters_from_overrides(true);
   auto move_group_node = rclcpp::Node::make_shared("move_group_interface_tutorial", node_options);
-
-  // We spin up a SingleThreadedExecutor for the current state monitor to get information
-  // about the robot's state.
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(move_group_node);
-  std::thread([&executor]() { executor.spin(); }).detach();
-
+  
   // BEGIN_TUTORIAL
   //
   // Setup
@@ -77,6 +71,12 @@ int main(int argc, char** argv)
   // :moveit_codedir:`MoveGroupInterface<moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h>`
   // class can be easily set up using just the name of the planning group you would like to control and plan for.
   moveit::planning_interface::MoveGroupInterface move_group(move_group_node, PLANNING_GROUP);
+  
+  // We spin up a SingleThreadedExecutor for the current state monitor to get information
+  // about the robot's state.
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(move_group_node);
+  std::thread([&executor]() { executor.spin(); }).detach();
 
   // We will use the
   // :moveit_codedir:`PlanningSceneInterface<moveit_ros/planning_interface/planning_scene_interface/include/moveit/planning_scene_interface/planning_scene_interface.h>`


### PR DESCRIPTION
**Description**

I'm specifically talking about this issue: https://github.com/ros-planning/moveit2/issues/1474. I only changed the order in which code is executed by creating the MoveGroup Interface before the executor.

The format of the code was not changed. The text explaining what the code does was also changed to represent the newly added/removed lines.

Takes over from PR #514 
