### PR TITLE
add spacenav example

### DIFF
--- a/doc/examples/realtime_servo/launch/servo_spacenav_input.launch.py
+++ b/doc/examples/realtime_servo/launch/servo_spacenav_input.launch.py
@@ -1,0 +1,17 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            Node(
+                package="spacenav",
+                executable="spacenav_node",
+                name="spacenav",
+                output="screen",
+                parameters=[{"zero_when_static": True, "use_twist_stamped": True}],
+                remappings=[("spacenav/twist", "servo_node/delta_twist_cmds")],
+            ),
+        ]
+    )

--- a/doc/examples/realtime_servo/realtime_servo_tutorial.rst
+++ b/doc/examples/realtime_servo/realtime_servo_tutorial.rst
@@ -31,6 +31,13 @@ Make a service request to start Servo ::
 
 You should be able to control the arm with your controller now, with MoveIt Servo automatically avoiding singularities and collisions.
 
+Using a SpaceMouse
+^^^^^^^^^^^^^^^^^^^^
+
+If you have a 3Dconnexion SpaceMouse, you can send 6DoF Cartesian commands using a single joystick. With the demo still running, in a new terminal, run ::
+
+    ros2 launch moveit2_tutorials servo_spacenav_input.launch.py
+
 Without a Controller
 ^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
### Description

Add a simple spacenav example, only launch file. Need to wait for https://github.com/ros-drivers/joystick_drivers/pull/251 to be merged. There I added an option to make spacenav_node publish TwistStamped directly.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
