### PR TITLE
Change max distance in Connect stages in MTC tutorial

### DIFF
--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
@@ -618,6 +618,7 @@ We need to move the arm to a position where we can pick up our object. This is d
           "move to pick",
           mtc::stages::Connect::GroupPlannerVector{ { arm_group_name, sampling_planner } });
       stage_move_to_pick->setTimeout(5.0);
+      stage_move_to_pick->setMaxDistance(1e-2);
       stage_move_to_pick->properties().configureInitFrom(mtc::Stage::PARENT);
       task.add(std::move(stage_move_to_pick));
 
@@ -794,6 +795,7 @@ Now that the stages that define the pick are complete, we move on to defining th
             mtc::stages::Connect::GroupPlannerVector{ { arm_group_name, sampling_planner },
                                                       { hand_group_name, interpolation_planner } });
         stage_move_to_place->setTimeout(5.0);
+        stage_move_to_place->setMaxDistance(1e-2);
         stage_move_to_place->properties().configureInitFrom(mtc::Stage::PARENT);
         task.add(std::move(stage_move_to_place));
       }

--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/src/mtc_node.cpp
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/src/mtc_node.cpp
@@ -138,6 +138,7 @@ mtc::Task MTCTaskNode::createTask()
       mtc::stages::Connect::GroupPlannerVector{ { arm_group_name, sampling_planner } });
   // clang-format on
   stage_move_to_pick->setTimeout(5.0);
+  stage_move_to_pick->setMaxDistance(1e-2);
   stage_move_to_pick->properties().configureInitFrom(mtc::Stage::PARENT);
   task.add(std::move(stage_move_to_pick));
 
@@ -263,6 +264,7 @@ mtc::Task MTCTaskNode::createTask()
                                                   { hand_group_name, interpolation_planner } });
     // clang-format on
     stage_move_to_place->setTimeout(5.0);
+    stage_move_to_place->setMaxDistance(1e-2);
     stage_move_to_place->properties().configureInitFrom(mtc::Stage::PARENT);
     task.add(std::move(stage_move_to_place));
   }


### PR DESCRIPTION
### Description

I was just trying to get MoveIt 2 tutorials working on Ubuntu 24.04 / Rolling and came back to this long-overdue fix.

This PR implements the suggestion from @rhaschke in https://github.com/moveit/moveit_task_constructor/issues/540#issuecomment-1988467097, which indeed fixes things on my end as well.