### PR TITLE
Use venv in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,9 +22,12 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Python dependencies
+      shell: bash
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y python3-pip
+        sudo apt-get install -y python3-pip python3-venv
+        python3 -m venv .venv
+        source .venv/bin/activate
         pip3 install --upgrade --requirement requirements.txt
 
     - name: Install doxygen and graphviz
@@ -39,6 +42,7 @@ jobs:
       run: |
         source /opt/ros/rolling/setup.bash
         source /root/ws_moveit/install/setup.bash
+        source .venv/bin/activate
         ./htmlproofer.sh
 
   upload_site_artifacts:
@@ -58,9 +62,12 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Python dependencies
+      shell: bash
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y python3-pip
+        sudo apt-get install -y python3-pip python3-venv
+        python3 -m venv .venv
+        source .venv/bin/activate
         pip3 install --upgrade --requirement requirements.txt
 
     - name: Install doxygen and graphviz
@@ -71,6 +78,7 @@ jobs:
       run: |
         source /opt/ros/${{ matrix.rosdistro }}/setup.bash
         source /root/ws_moveit/install/setup.bash
+        source .venv/bin/activate
         make generate_api_artifacts BRANCH=${{ matrix.branch }}
 
     - name: Compress Artifact

--- a/doc/how_to_contribute/how_to_contribute_to_site.rst
+++ b/doc/how_to_contribute/how_to_contribute_to_site.rst
@@ -53,7 +53,7 @@ Steps
 
     pip3 install --upgrade --requirement requirements.txt
 
-  You can run the script with this command:
+  You can run the ``htmlproofer`` script with this command:
 
   .. code-block:: bash
 

--- a/doc/how_to_contribute/how_to_contribute_to_site.rst
+++ b/doc/how_to_contribute/how_to_contribute_to_site.rst
@@ -40,7 +40,20 @@ Steps
 
 2. Test for broken links
 
-  To test for broken links run this command:
+  To test for broken links, run the ``htmlproofer`` script. Note that running this script may require you to install some Python dependencies. If using ``pip`` to install these dependencies, you may want to create a virtual environment. 
+
+  .. code-block:: bash
+
+    python3 -m venv .venv
+    source .venv/bin/activate
+
+  You can then install requirements using ``pip``:
+
+  .. code-block:: bash
+
+    pip3 install --upgrade --requirement requirements.txt
+
+  You can run the script with this command:
 
   .. code-block:: bash
 

--- a/doc/how_to_contribute/how_to_contribute_to_site.rst
+++ b/doc/how_to_contribute/how_to_contribute_to_site.rst
@@ -40,7 +40,7 @@ Steps
 
 2. Test for broken links
 
-  To test for broken links, run the ``htmlproofer`` script. Note that running this script may require you to install some Python dependencies. If using ``pip`` to install these dependencies, you may want to create a virtual environment. 
+  To test for broken links, run the ``htmlproofer`` script. Note that running this script may require you to install some Python dependencies. If using ``pip`` to install these dependencies, you may want to create a virtual environment.
 
   .. code-block:: bash
 

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Note that a virtual environment is required when running this script in CI
 set -e
 
 # Define some config vars

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -12,7 +12,7 @@ gem install --user-install html-proofer -v 3.19.4 # newer 4.x requires different
 PATH="$(ruby -r rubygems -e 'puts Gem.user_dir')/bin:$PATH"
 
 # Install python dependencies
-pip3 install --user --upgrade -r requirements.txt
+pip3 install --upgrade -r requirements.txt
 
 # Clear out any previous builds
 rm -rf build


### PR DESCRIPTION
### Description

Fix this error:

```
 error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.
```

This should make CI pass the "Install Python Dependencies" step.

