### PR TITLE
Fix htmlproofer CI job on Ubuntu 24.04

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,7 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y python3-pip
+        export PIP_BREAK_SYSTEM_PACKAGES=1
         pip3 install --upgrade --requirement requirements.txt
 
     - name: Install doxygen and graphviz
@@ -99,6 +100,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
+        export PIP_BREAK_SYSTEM_PACKAGES=1
         pip install --upgrade --requirement requirements.txt
 
     - name: Install doxygen and graphviz

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y python3-pip
+        export PIP_BREAK_SYSTEM_PACKAGES=1
         pip3 install --upgrade --requirement requirements.txt
 
     - name: Install doxygen and graphviz

--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -7,12 +7,14 @@ export REPOSITORY_NAME=${PWD##*/}
 export MOVEIT_BRANCH=main
 echo "Testing branch $MOVEIT_BRANCH of $REPOSITORY_NAME"
 
-# Install htmlpoofer
+# Install htmlproofer
 gem install --user-install html-proofer -v 3.19.4 # newer 4.x requires different cmdline options
 PATH="$(ruby -r rubygems -e 'puts Gem.user_dir')/bin:$PATH"
 
 # Install python dependencies
-pip3 install --user --upgrade -r requirements.txt
+# NOTE: This needs to be moved to a virtual environment on Ubunty 24.04 or later,
+# instead of adding the --break-system-packages flag.
+pip3 install --break-system-packages --user --upgrade -r requirements.txt
 
 # Clear out any previous builds
 rm -rf build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pip
 docutils==0.18.1
 sphinx>=5.0.0
 sphinx-tabs==3.4.4


### PR DESCRIPTION
### Description

In Ubuntu 24.04, you can't `pip install` into System Python, encouraging you to use a virtual environment.

As a stop-gap, we can set an environment variable to allow this, which I think is fine just for the docs build job.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
