### PR TITLE
Use fork of `ros2_kortex` that does not depend on Gazebo classic

### DIFF
--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -16,10 +16,12 @@ repositories:
     url: https://github.com/PickNikRobotics/rviz_visual_tools.git
     version: ros2
   # Remove ros2_kortex when rolling binaries are available.
+  # Need to use this fork since ros2_kortex depends on Gazebo classic packages:
+  # https://github.com/Kinovarobotics/ros2_kortex/issues/217
   ros2_kortex:
     type: git
-    url: https://github.com/Kinovarobotics/ros2_kortex.git
-    version: main
+    url: https://github.com/sea-bass/ros2_kortex.git
+    version: remove-gazebo-classic
   # Remove ros2_robotiq_gripper when rolling binaries are available.
   ros2_robotiq_gripper:
     type: git
@@ -30,9 +32,3 @@ repositories:
     type: git
     url: https://github.com/tylerjw/serial.git
     version: ros2
-  # This needs to be included due to the ros2_kortex repo:
-  # https://github.com/Kinovarobotics/ros2_kortex/issues/217
-  gazebo_ros2_control:
-    type: git
-    url: https://github.com/ros-controls/gazebo_ros2_control
-    version: master

--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -32,3 +32,8 @@ repositories:
     type: git
     url: https://github.com/tylerjw/serial.git
     version: ros2
+  # Doesn't seem to be available from binaries yet  
+  gz_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gz_ros2_control.git
+    version: master

--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -32,7 +32,7 @@ repositories:
     type: git
     url: https://github.com/tylerjw/serial.git
     version: ros2
-  # Doesn't seem to be available from binaries yet  
+  # Doesn't seem to be available from binaries yet
   gz_ros2_control:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git

--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -30,3 +30,9 @@ repositories:
     type: git
     url: https://github.com/tylerjw/serial.git
     version: ros2
+  # This needs to be included due to the ros2_kortex repo:
+  # https://github.com/Kinovarobotics/ros2_kortex/issues/217
+  gazebo_ros2_control
+    type: git
+    url: https://github.com/ros-controls/gazebo_ros2_control
+    version: master

--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -32,7 +32,7 @@ repositories:
     version: ros2
   # This needs to be included due to the ros2_kortex repo:
   # https://github.com/Kinovarobotics/ros2_kortex/issues/217
-  gazebo_ros2_control
+  gazebo_ros2_control:
     type: git
     url: https://github.com/ros-controls/gazebo_ros2_control
     version: master

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -8,10 +8,12 @@ repositories:
     url: https://github.com/moveit/moveit_visual_tools
     version: ros2
   # Remove ros2_kortex when rolling binaries are available.
+  # Need to use this fork since ros2_kortex depends on Gazebo classic packages:
+  # https://github.com/Kinovarobotics/ros2_kortex/issues/217
   ros2_kortex:
     type: git
-    url: https://github.com/Kinovarobotics/ros2_kortex.git
-    version: main
+    url: https://github.com/sea-bass/ros2_kortex.git
+    version: remove-gazebo-classic
   # Remove ros2_robotiq_gripper when rolling binaries are available.
   ros2_robotiq_gripper:
     type: git
@@ -42,9 +44,3 @@ repositories:
     type: git
     url: https://github.com/PickNikRobotics/pick_ik
     version: main
-  # This needs to be included due to the ros2_kortex repo:
-  # https://github.com/Kinovarobotics/ros2_kortex/issues/217
-  gazebo_ros2_control:
-    type: git
-    url: https://github.com/ros-controls/gazebo_ros2_control
-    version: master

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -44,7 +44,7 @@ repositories:
     type: git
     url: https://github.com/PickNikRobotics/pick_ik
     version: main
-  # Doesn't seem to be available from binaries yet  
+  # Doesn't seem to be available from binaries yet
   gz_ros2_control:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -44,7 +44,7 @@ repositories:
     version: main
   # This needs to be included due to the ros2_kortex repo:
   # https://github.com/Kinovarobotics/ros2_kortex/issues/217
-  gazebo_ros2_control
+  gazebo_ros2_control:
     type: git
     url: https://github.com/ros-controls/gazebo_ros2_control
     version: master

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -44,3 +44,8 @@ repositories:
     type: git
     url: https://github.com/PickNikRobotics/pick_ik
     version: main
+  # Doesn't seem to be available from binaries yet  
+  gz_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gz_ros2_control.git
+    version: master

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -42,3 +42,9 @@ repositories:
     type: git
     url: https://github.com/PickNikRobotics/pick_ik
     version: main
+  # This needs to be included due to the ros2_kortex repo:
+  # https://github.com/Kinovarobotics/ros2_kortex/issues/217
+  gazebo_ros2_control
+    type: git
+    url: https://github.com/ros-controls/gazebo_ros2_control
+    version: master


### PR DESCRIPTION
### Description

In Ubuntu 24.04, Gazebo classic is no longer supported or available from binaries. Due to the `ros2_kortex` repo still using this as a dependency, CI has been failing.

See: https://github.com/Kinovarobotics/ros2_kortex/issues/217 and https://github.com/Kinovarobotics/ros2_kortex/pull/228

So, to have this work, we (and all consumers of this package on Jazzy onwards) have to get around this.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
