### PR TITLE
Fix wrong launch package in Setup Assistant tutorial

### DIFF
--- a/doc/examples/setup_assistant/setup_assistant_tutorial.rst
+++ b/doc/examples/setup_assistant/setup_assistant_tutorial.rst
@@ -504,7 +504,7 @@ To build only the generated ``panda_moveit_config`` package and run the demo, fo
 
 Start the MoveIt demo to interactively plan and execute motions for the robot in RViz. ::
 
-   ros2 launch moveit_resources_panda_moveit_config demo.launch.py
+   ros2 launch panda_moveit_config demo.launch.py
 
 Check out this `brief YouTube video <https://youtu.be/f__udZlnTdM>`_ for an example of how to
 command the robot to move to the pre-defined ``ready`` pose and execute ``open`` and ``close`` motions on the hand.


### PR DESCRIPTION
In the example section, after building our "own" robot, we need to launch the `demo.launch.py`. Here, the wrong package to launch from is set (already builtin in tutorial source, `moveit_resouces`) to the `moveit_resouces_panda_moveit_config` instead of built `panda_moveit_config`.