### PR TITLE
Fix stray pip user install

### DIFF
--- a/build_locally.sh
+++ b/build_locally.sh
@@ -41,7 +41,7 @@ fi
 # Install dependencies, unless argument says to skip
 if ! have_noinstall "$@"; then
   sudo apt-get install -y doxygen graphviz
-  pip3 install --user --upgrade -r requirements.txt
+  pip3 install --upgrade -r requirements.txt
 fi
 
 # A fresh build is required because changes to some components such as css files does not rebuilt currently


### PR DESCRIPTION
While I was testing @sea-bass's fixes, I noticed the build locally script doesn't work. Looks like I missed a stray `pip install --user` in #916 .