### PR TITLE
Install Gazebo as part of Tutorials image build

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,12 +1,15 @@
 # syntax = docker/dockerfile:1.3
 
 ARG ROS_DISTRO=rolling
+ARG GZ_VERSION=8
 
 ######################### Tutorial Image  #################################################
 
 FROM moveit/moveit2:${ROS_DISTRO}-source as tutorial_image
 
 LABEL org.opencontainers.image.description "This container has working versions of the tutorials discussed here: https://moveit.picknik.ai/main/doc/tutorials/tutorials.html"
+
+ARG GZ_VERSION
 
 # Copy sources from docker context
 COPY . src/moveit2_tutorials
@@ -44,6 +47,12 @@ COPY ./doc/tutorials/pick_and_place_with_moveit_task_constructor/src/mtc_node.cp
 
 # Add the launch folder to the tutorial package and CMakeLists.txt
 COPY ./doc/tutorials/pick_and_place_with_moveit_task_constructor/launch src/mtc_tutorial/launch
+
+# Install Gazebo, which is needed by some dependencies.
+RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' && \
+    wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add - && \
+    sudo apt update && \
+    sudo apt-get install -y "libgz-sim${GZ_VERSION}-dev"
 
 # Add install(DIRECTORY launch  DESTINATION share/${PROJECT_NAME}) to CMakeLists.txt
 RUN sed -i "s|ament_package()|install(DIRECTORY launch  DESTINATION share/\${PROJECT_NAME})\nament_package()|g" src/mtc_tutorial/CMakeLists.txt

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1.3
 
 ARG ROS_DISTRO=rolling
-ARG GZ_VERSION=8
+ARG GZ_VERSION=harmonic
 
 ######################### Tutorial Image  #################################################
 
@@ -52,7 +52,7 @@ COPY ./doc/tutorials/pick_and_place_with_moveit_task_constructor/launch src/mtc_
 RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' && \
     wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add - && \
     sudo apt update && \
-    sudo apt-get install -y "libgz-sim${GZ_VERSION}-dev"
+    sudo apt-get install -y "gz-${GZ_VERSION}"
 
 # Add install(DIRECTORY launch  DESTINATION share/${PROJECT_NAME}) to CMakeLists.txt
 RUN sed -i "s|ament_package()|install(DIRECTORY launch  DESTINATION share/\${PROJECT_NAME})\nament_package()|g" src/mtc_tutorial/CMakeLists.txt


### PR DESCRIPTION
### Description

There have been issues building the tutorials image because now some of the packages (namely Robotiq and ros2_kortex) depend on Gazebo being installed.

This will work for Jazzy/Rolling, but I think there need to be args introduced to make this work on other distros (or even changing `gz` for `ignition`)

So you will then need to pass in this `GZ_VERSION` arg in the `moveit2` CI job here: https://github.com/moveit/moveit2/blob/1d93035fc4fbc2831916bce26d7b03e15b8a86d5/.github/workflows/tutorial_docker.yaml#L19

NOTE: You should see the effects of this in the post-merge action for this PR. I've also dispatched the workflow so you can see it on this branch: https://github.com/moveit/moveit2_tutorials/actions/runs/10207096230

(all previous failing runs can be found here: https://github.com/moveit/moveit2_tutorials/actions/workflows/docker.yml)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
