### PR TITLE
Fixed link typo in Warehouse - Persistent Scenes and States page

### DIFF
--- a/doc/how_to_guides/persistent_scenes_and_states/persistent_scenes_and_states.rst
+++ b/doc/how_to_guides/persistent_scenes_and_states/persistent_scenes_and_states.rst
@@ -32,7 +32,7 @@ If the database file does not exist yet, an empty database will be created.
 Connecting to the storage backend
 ---------------------------------
 
-To run the demo you need to install git lfs by running ``git lfs install`` and clone [moveit_benchmark_resources](https://github.com/moveit/moveit_benchmark_resources.git) into your workspace.
+To run the demo you need to install git lfs by running ``git lfs install`` and clone `moveit_benchmark_resources <https://github.com/moveit/moveit_benchmark_resources.git>`_ into your workspace.
 
 After choosing the storage plugin and configuring the launch.py file,
 run RViz using ::


### PR DESCRIPTION
### Description

Broken link highlighting in Warehouse - Persistent Scenes and States page is fixed.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
