### PR TITLE
Update benchmarking_tutorial.rst

### DIFF
--- a/doc/how_to_guides/benchmarking/benchmarking_tutorial.rst
+++ b/doc/how_to_guides/benchmarking/benchmarking_tutorial.rst
@@ -11,7 +11,7 @@ The example below demonstrates how the benchmarking can be run.
 Example
 -------
 
-To run the example you need to install git lfs by running ``git lfs install`` and clone [moveit_benchmark_resources](https://github.com/moveit/moveit_benchmark_resources.git) into your workspace.
+To run the example you need to install git lfs by running ``git lfs install`` and clone `moveit_benchmark_resources <https://github.com/moveit/moveit_benchmark_resources.git`_ into your workspace.
 
 Start the benchmarks by running: ::
 


### PR DESCRIPTION
Markdown links look like this:
![image](https://github.com/user-attachments/assets/5752c912-8348-41f9-88d8-d72d41c63988)

That's not desirable.