### PR TITLE
Add branch to `git clone` command in Getting Started docs

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -62,7 +62,7 @@ Download Source Code of MoveIt and the Tutorials
 Move into your Colcon workspace and pull the MoveIt tutorials source, where ``<branch>`` can be e.g. ``humble`` for ROS Humble, or ``main`` for the latest version of the tutorials : ::
 
   cd ~/ws_moveit/src
-  git clone -b <branch-name> https://github.com/moveit/moveit2_tutorials
+  git clone -b <branch> https://github.com/moveit/moveit2_tutorials
 
 Next we will download the source code for the rest of MoveIt: ::
 

--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -62,7 +62,7 @@ Download Source Code of MoveIt and the Tutorials
 Move into your Colcon workspace and pull the MoveIt tutorials source, where ``<branch>`` can be e.g. ``humble`` for ROS Humble, or ``main`` for the latest version of the tutorials : ::
 
   cd ~/ws_moveit/src
-  git clone https://github.com/moveit/moveit2_tutorials
+  git clone -b <branch-name> https://github.com/moveit/moveit2_tutorials
 
 Next we will download the source code for the rest of MoveIt: ::
 


### PR DESCRIPTION
Modified the cloning instructions to specify a branch explicitly. This change aims to prevent common pitfalls encountered by users related to missing or incompatible packages when using older ROS distributions. By directing users to clone a specific branch, we ensure that they start with a setup that is compatible with their environment, thus reducing initial setup errors and improving the onboarding experience.