### PR TITLE
Added code to update submodules during installation

### DIFF
--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -66,23 +66,10 @@ Move into your Colcon workspace and pull the MoveIt tutorials source, where ``<b
 
 Next we will download the source code for the rest of MoveIt: ::
 
-  vcs import < moveit2_tutorials/moveit2_tutorials.repos
+  vcs import --recursive < moveit2_tutorials/moveit2_tutorials.repos
 
 The import command may ask for your GitHub credentials.
 You can just press Enter until it moves on (ignore the "Authentication failed" error).
-
-Next update submodules: ::
-
-  # Loop over all directories that might contain submodules
-  for dir in */; do
-      cd "$dir"
-      # Check if .gitmodules exists and if so, init and update submodules
-      if [ -f .gitmodules ]; then
-          echo "Initializing and updating submodules in $dir"
-          git submodule update --init --recursive
-      fi
-      cd ..
-  done
 
 Build your Colcon Workspace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/tutorials/getting_started/getting_started.rst
+++ b/doc/tutorials/getting_started/getting_started.rst
@@ -71,6 +71,19 @@ Next we will download the source code for the rest of MoveIt: ::
 The import command may ask for your GitHub credentials.
 You can just press Enter until it moves on (ignore the "Authentication failed" error).
 
+Next update submodules: ::
+
+  # Loop over all directories that might contain submodules
+  for dir in */; do
+      cd "$dir"
+      # Check if .gitmodules exists and if so, init and update submodules
+      if [ -f .gitmodules ]; then
+          echo "Initializing and updating submodules in $dir"
+          git submodule update --init --recursive
+      fi
+      cd ..
+  done
+
 Build your Colcon Workspace
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 First remove all previously installed moveit binaries: ::


### PR DESCRIPTION
Added code to automatically initialize and update all submodules recursively. This change addresses build errors related to un-initialized submodules, specifically issues with the `pybind11` submodule. The script checks each directory for the presence of `.gitmodules` and, if found, performs the necessary submodule updates. This ensures all dependencies are correctly set up before build, improving the reliability of our build process and reducing setup errors for new users.