### PR TITLE
Update moveit2_tutorials.repos

### DIFF
--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -48,4 +48,4 @@ repositories:
   gz_ros2_control:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git
-    version: master
+    version: rolling


### PR DESCRIPTION
Updating the git branch for gz_ros2_control repo to rolling since master branch doesn't exist.