### PR TITLE
Update gz_ros2_control branch name in upstream.repos

### DIFF
--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -36,4 +36,4 @@ repositories:
   gz_ros2_control:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git
-    version: master
+    version: rolling


### PR DESCRIPTION
### Description

The `gz_ros2_control` repo updated their default branch recently. This should fix builds.

It's the same change as https://github.com/moveit/moveit2_tutorials/pull/955, but for some reason we need this in 2 places.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
