### PR TITLE
CI: Use actions/cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: cache upstream_ws
-        uses: pat-s/always-upload-cache@v3.0.11
+        uses: actions/cache@v4
         with:
+          save-always: true
           path: ${{ env.BASEDIR }}/upstream_ws
           key: upstream_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('.github/upstream.repos') }}-${{ github.run_id }}
           restore-keys: |
@@ -48,15 +49,17 @@ jobs:
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: cache target_ws
-        uses: pat-s/always-upload-cache@v3.0.11
+        uses: actions/cache@v4
         with:
+          save-always: true
           path: ${{ env.BASEDIR }}/target_ws
           key: target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}-${{ github.run_id }}
           restore-keys: |
             target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
       - name: cache ccache
-        uses: pat-s/always-upload-cache@v3.0.11
+        uses: actions/cache@v4
         with:
+          save-always: true
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |


### PR DESCRIPTION
Since version 4, `actions/cache` supports the setting `save-always`.