### PR TITLE
MoveGroup naming inconsitency

### DIFF
--- a/doc/tutorials/your_first_project/your_first_project.rst
+++ b/doc/tutorials/your_first_project/your_first_project.rst
@@ -139,7 +139,7 @@ In place of the comment that says "Next step goes here", add this code:
 
   // Create the MoveIt MoveGroup Interface
   using moveit::planning_interface::MoveGroupInterface;
-  auto move_group_interface = MoveGroupInterface(node, "manipulator");
+  auto move_group_interface = MoveGroupInterface(node, "panda_arm");
 
   // Set a target Pose
   auto const target_pose = []{
@@ -222,7 +222,7 @@ That is the group of joints as defined in the robot description that we are goin
 .. code-block:: C++
 
   using moveit::planning_interface::MoveGroupInterface;
-  auto move_group_interface = MoveGroupInterface(node, "manipulator");
+  auto move_group_interface = MoveGroupInterface(node, "panda_arm");
 
 Then, we set our target pose and plan. Note that only the target pose is set (via ``setPoseTarget``).
 The starting pose is implicitly the position published by the joint state publisher, which could be changed using the


### PR DESCRIPTION
The MoveGroup name in hello_moveit.cpp does not match the one sued in panda.srdf, leading to errors while running `ros2 run hello_moveit hello_moveit`

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
