### PR TITLE
Fix formatting in tutorials index page URL

### DIFF
--- a/doc/tutorials/tutorials.rst
+++ b/doc/tutorials/tutorials.rst
@@ -6,7 +6,7 @@ These tutorials will quickly get you using the MoveIt 2 Motion Planning Framewor
 .. image:: quickstart_in_rviz/rviz_plugin_head.png
    :width: 700px
 
-In these tutorials, the [Kinova Gen3](https://github.com/Kinovarobotics/ros2_kortex) robot is used as a quick-start demo.
+In these tutorials, the `Kinova Gen3 <https://github.com/Kinovarobotics/ros2_kortex>`_ robot is used as a quick-start demo.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
### Description

I committed changes in Markdown format, not RST format. Oops.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
