### PR TITLE
Install `gz_ros2_control` from binaries

### DIFF
--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -32,8 +32,3 @@ repositories:
     type: git
     url: https://github.com/tylerjw/serial.git
     version: ros2
-  # Doesn't seem to be available from binaries yet
-  gz_ros2_control:
-    type: git
-    url: https://github.com/ros-controls/gz_ros2_control.git
-    version: rolling

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -44,8 +44,3 @@ repositories:
     type: git
     url: https://github.com/PickNikRobotics/pick_ik
     version: main
-  # Doesn't seem to be available from binaries yet
-  gz_ros2_control:
-    type: git
-    url: https://github.com/ros-controls/gz_ros2_control.git
-    version: rolling


### PR DESCRIPTION
### Description

Now that `gz_ros2_control` is available from binaries on Iron onwards, we can remove this source build.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
