### PR TITLE
Remove/replace deprecated use of JumpThreshold

### DIFF
--- a/doc/examples/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/examples/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -304,15 +304,10 @@ int main(int argc, char** argv)
   target_pose3.position.x -= 0.2;
   waypoints.push_back(target_pose3);  // up and left
 
-  // We want the Cartesian path to be interpolated at a resolution of 1 cm
-  // which is why we will specify 0.01 as the max step in Cartesian
-  // translation.  We will specify the jump threshold as 0.0, effectively disabling it.
-  // Warning - disabling the jump threshold while operating real hardware can cause
-  // large unpredictable motions of redundant joints and could be a safety issue
-  moveit_msgs::msg::RobotTrajectory trajectory;
-  const double jump_threshold = 0.0;
+  // We want the Cartesian path to be interpolated at a resolution of 1 cm.
   const double eef_step = 0.01;
-  double fraction = move_group.computeCartesianPath(waypoints, eef_step, jump_threshold, trajectory);
+  moveit_msgs::msg::RobotTrajectory trajectory;
+  double fraction = move_group.computeCartesianPath(waypoints, eef_step, trajectory);
   RCLCPP_INFO(LOGGER, "Visualizing plan 4 (Cartesian path) (%.2f%% achieved)", fraction * 100.0);
 
   // Visualize the plan in RViz

--- a/doc/examples/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/doc/examples/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -304,7 +304,8 @@ int main(int argc, char** argv)
   target_pose3.position.x -= 0.2;
   waypoints.push_back(target_pose3);  // up and left
 
-  // We want the Cartesian path to be interpolated at a resolution of 1 cm.
+  // We want the Cartesian path to be interpolated at a resolution of 1 cm,
+  // which is why we will specify 0.01 as the max step in Cartesian translation.
   const double eef_step = 0.01;
   moveit_msgs::msg::RobotTrajectory trajectory;
   double fraction = move_group.computeCartesianPath(waypoints, eef_step, trajectory);

--- a/doc/how_to_guides/kinematics_cost_function/src/kinematics_cost_function_tutorial.cpp
+++ b/doc/how_to_guides/kinematics_cost_function/src/kinematics_cost_function_tutorial.cpp
@@ -216,14 +216,15 @@ int main(int argc, char** argv)
   auto start_state = move_group.getCurrentState(10.0);
   std::vector<moveit::core::RobotStatePtr> traj;
   moveit::core::MaxEEFStep max_eef_step(0.01, 0.1);
-  // Here, we're effectively disabling the jump threshold for joints. This is not recommended on real hardware.
-  const auto jump_thresh = moveit::core::JumpThreshold::disabled();
+  moveit::core::CartesianPrecision cartesian_precision{ .translational = 0.001,
+                                                        .rotational = 0.01,
+                                                        .max_resolution = 1e-3 };
 
   // The trajectory, traj, passed to computeCartesianPath will contain several waypoints toward
   // the goal pose, target. For each of these waypoints, the IK solver is queried with the given cost function.
   const auto frac = moveit::core::CartesianInterpolator::computeCartesianPath(
       start_state.get(), joint_model_group, traj, joint_model_group->getLinkModel("panda_link8"), target, true,
-      max_eef_step, jump_thresh, callback_fn, opts, cost_fn);
+      max_eef_step, cartesian_precision, callback_fn, opts, cost_fn);
 
   RCLCPP_INFO(LOGGER, "Computed %f percent of cartesian path.", frac.value * 100.0);
 


### PR DESCRIPTION
### Description

Since https://github.com/moveit/moveit2/pull/2916, the `JumpThreshold` in cartesian interpolator was removed and/or replaced with a `CartesianPrecision` struct.

This PR brings things up to date, thereby removing deprecation warnings when compiling.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
