### PR TITLE
Update tutorial Docker image names and documentation

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,5 +1,5 @@
 # Example command:
-#   Humble on a Nvidia system:
+#   Humble on a NVIDIA system:
 #   DOCKER_IMAGE=humble-humble-tutorial-source docker compose run gpu
 #   Rolling without discrete graphics:
 #   DOCKER_IMAGE=main-rolling-tutorial-source compose run cpu

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,12 +1,12 @@
 # Example command:
 #   Humble on a Nvidia system:
-#   DOCKER_IMAGE=humble-tutorial docker compose run gpu
+#   DOCKER_IMAGE=humble-humble-tutorial-source docker compose run gpu
 #   Rolling without discrete graphics:
-#   DOCKER_IMAGE=rolling-tutorial docker compose run cpu
+#   DOCKER_IMAGE=main-rolling-tutorial-source compose run cpu
 
 services:
   cpu:
-    image: ghcr.io/moveit/moveit2_tutorials:$DOCKER_IMAGE
+    image: moveit/moveit2:${DOCKER_IMAGE}
     container_name: moveit2_container
     privileged: true
     network_mode: host
@@ -18,7 +18,7 @@ services:
       QT_X11_NO_MITSHM: 1
       DISPLAY: $DISPLAY
   gpu:
-    image: ghcr.io/moveit/moveit2_tutorials:$DOCKER_IMAGE
+    image: moveit/moveit2:${DOCKER_IMAGE}
     container_name: moveit2_container
     privileged: true
     network_mode: host

--- a/README.md
+++ b/README.md
@@ -48,12 +48,20 @@ Configure and build the workspace:
 
 ## Build HTML Pages Locally
 
-If you want to test the tutorials by generating the HTML pages locally on your machine, you can use the ``build_locally`` script by issuing the following commands in the root of the moveit2_tutorials package:
+If you want to test the tutorials by generating the HTML pages locally on your machine, you can use the ``build_locally.sh`` script in this repo.
 
-    export ROS_DISTRO=rolling  # 20.04
+If you are using Ubuntu 24.04 (or Python 3.11 or greater), you should first create a virtual environment.
+
+    python3 -m venv .venv
+    source .venv/bin/activate
+
+Then, issue the following commands in the root of the ``moveit2_tutorials`` package:
 
     cd $COLCON_WS/src/moveit2_tutorials
+
+    export ROS_DISTRO=rolling  # 24.04
     source /opt/ros/$ROS_DISTRO/setup.bash
+
     ./build_locally.sh
 
 The local website ``<LOCAL_PACKAGE_PATH>/build/html/index.html`` should automatically open in your web browser.

--- a/doc/how_to_guides/how_to_setup_docker_containers_in_ubuntu.rst
+++ b/doc/how_to_guides/how_to_setup_docker_containers_in_ubuntu.rst
@@ -13,16 +13,17 @@ Learning Objectives
 Requirements
 ------------
 
-- Ubuntu 20.04 or 22.04
+- Ubuntu 22.04 or 24.04
 - `Docker Installation for Ubuntu <https://docs.docker.com/engine/install/ubuntu/>`_
-- `Nvidia drivers for Docker <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#setting-up-nvidia-container-toolkit>`_
+- `NVIDIA drivers for Docker <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#setting-up-nvidia-container-toolkit>`_
 - `docker compose (if not already installed via Docker Desktop) <https://docs.docker.com/compose/install/>`_
 
 Steps
 -----
-1. Install Docker and docker compose (links are available in the Requirements section) and be sure to follow the `Linux Post Install <https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user>`_ instructions. If you do not complete these additional steps you will need to preface all ``docker`` commands with ``sudo``.
+1. Install Docker and docker compose (links are available in the Requirements section) and be sure to follow the `Linux Post Install instructions <https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user>`_.
+If you do not complete these additional steps you will need to preface all ``docker`` commands with ``sudo``.
 
-2. Open a terminal session and download docker-compose.yml
+2. Open a terminal session and download ``docker-compose.yml``
 
   .. code-block:: bash
 
@@ -32,11 +33,16 @@ Steps
 
    .. code-block:: bash
 
-    DOCKER_IMAGE=rolling-tutorial docker compose run --rm --name moveit2_container gpu
+    DOCKER_IMAGE=main-rolling-tutorial-source docker compose run --rm --name moveit2_container gpu
 
-   You can replace ``rolling-tutorial`` with other tagged images, e.g. ``humble-tutorial``. Similarly, you can replace ``gpu`` with ``cpu`` if you do not wish to run using Nvidia GPU drivers and you can change the name of the container by replacing ``moveit2_container``. The ``--rm`` argument will remove the container when you stop (or exit) it, otherwise you can keep your modified container on disk and start it using ``docker start moveit2_container``
+   You can replace ``DOCKER_IMAGE`` with other Docker image names, such as ``main-jazzy-tutorial-source`` or ``humble-humble-tutorial source``.
+   This is based on the convention ``<MoveIt branch name>-<ROS distro name>-tutorial-source``.
 
-4. You should now be inside of your Docker container, in the workspace directory, with the completed :doc:`Planning Around Objects </doc/tutorials/planning_around_objects/planning_around_objects>` and :doc:`Pick and Place with MoveIt Task Constructor </doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor>` tutorials. Go ahead and try one of the launch commands like ``ros2 launch moveit2_tutorials demo.launch.py``
+   Similarly, you can replace the ``gpu`` service name with ``cpu`` if you do not wish to run using Nvidia GPU drivers and you can change the name of the container by replacing ``moveit2_container``.
+   The ``--rm`` argument will remove the container when you stop (or exit) it, otherwise you can keep your modified container on disk and start it using ``docker start moveit2_container``.
+
+4. You should now be inside of your Docker container, in the workspace directory, with the completed :doc:`Planning Around Objects </doc/tutorials/planning_around_objects/planning_around_objects>` and :doc:`Pick and Place with MoveIt Task Constructor </doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor>` tutorials.
+Go ahead and try one of the launch commands like ``ros2 launch moveit2_tutorials demo.launch.py``.
 
   If you wish to enter the container through another terminal, use:
 
@@ -48,11 +54,12 @@ Further Reading
 ---------------
 - For more information about Docker best practices with respect to MoveIt,
   refer to `this blog post <https://picknik.ai/ros/robotics/docker/2021/07/20/Vatan-Aksoy-Tezer-Docker.html>`_
-  from PickNik's Vatan Aksoy Tezer and Brennard Pierce.
+  from Vatan Aksoy Tezer and Brennand Pierce.
 
-- There are tagged images for both ``rolling`` and ``humble`` which are built on top of the ``rolling-source`` and ``humble-source`` MoveIt 2 Docker images `here <https://hub.docker.com/r/moveit/moveit2/tags>`__.
+- There are tagged images for ``rolling``, ``jazzy``, and ``humble`` which are built on top of MoveIt 2 Docker images `here <https://hub.docker.com/r/moveit/moveit2/tags>`__.
 
 - You can find more tagged images for MoveIt 2 Docker containers `here <https://hub.docker.com/r/moveit/moveit2/tags>`__.
-  The tagged images coincide with ROS2 version releases. The ``release`` version of the container provides an environment in which MoveIt 2 is installed via the binaries.
+  The tagged images coincide with ROS 2 version releases.
+  The ``release`` version of the container provides an environment in which MoveIt 2 is installed via the binaries.
   The ``source`` version of the Docker image will build MoveIt 2 from source.
-  You can use any of these images by substituting the DOCKER_IMAGE environment variable with a tag name from the above link (like ``rolling-source``), but you must use `this docker-compose.yml <https://raw.githubusercontent.com/moveit/moveit2_tutorials/main/_scripts/docker-compose.yml>`_ instead (simply copy it to a different location and run your ``docker compose`` command there).
+  You can use any of these images by substituting the ``DOCKER_IMAGE `` environment variable with a tag name from the above link (like ``main-rolling-tutorial-source``), but you must use `this docker-compose.yml <https://raw.githubusercontent.com/moveit/moveit2_tutorials/main/_scripts/docker-compose.yml>`_ instead (simply copy it to a different location and run your ``docker compose`` command there).

--- a/doc/how_to_guides/how_to_setup_docker_containers_in_ubuntu.rst
+++ b/doc/how_to_guides/how_to_setup_docker_containers_in_ubuntu.rst
@@ -38,7 +38,7 @@ If you do not complete these additional steps you will need to preface all ``doc
    You can replace ``DOCKER_IMAGE`` with other Docker image names, such as ``main-jazzy-tutorial-source`` or ``humble-humble-tutorial source``.
    This is based on the convention ``<MoveIt branch name>-<ROS distro name>-tutorial-source``.
 
-   Similarly, you can replace the ``gpu`` service name with ``cpu`` if you do not wish to run using Nvidia GPU drivers and you can change the name of the container by replacing ``moveit2_container``.
+   Similarly, you can replace the ``gpu`` service name with ``cpu`` if you do not wish to run using NVIDIA GPU drivers and you can change the name of the container by replacing ``moveit2_container``.
    The ``--rm`` argument will remove the container when you stop (or exit) it, otherwise you can keep your modified container on disk and start it using ``docker start moveit2_container``.
 
 4. You should now be inside of your Docker container, in the workspace directory, with the completed :doc:`Planning Around Objects </doc/tutorials/planning_around_objects/planning_around_objects>` and :doc:`Pick and Place with MoveIt Task Constructor </doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor>` tutorials.


### PR DESCRIPTION
### Description

This PR updates the Docker images used in the tutorials to the new `moveit` Docker Hub organization.

It also updates docs associated with this change, plus how to build documentation locally with virtual environments (needed for Ubuntu 24.04, introduced in #916)

I also tested all the combinations for Humble, Jazzy, and Rolling, and the `demo.launch.py` actually work in all 3 cases! Magical.

Closes https://github.com/moveit/moveit2_tutorials/issues/936

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
