### PR TITLE
Remove pick_ik as a dependency

### DIFF
--- a/doc/how_to_guides/pick_ik/pick_ik_tutorial.rst
+++ b/doc/how_to_guides/pick_ik/pick_ik_tutorial.rst
@@ -78,7 +78,7 @@ robot's config directory to use pick_ik as the IK solver. ::
 
 .. note::
 
-   You can launch a preconfigured demo with ``pick_ik`` using the following command:
+   After you have installed ``pick_ik``, you can also launch a preconfigured demo using the following command:
 
    .. code-block::
 

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -40,7 +40,3 @@ repositories:
     type: git
     url: https://github.com/moveit/moveit_msgs
     version: ros2
-  pick_ik:
-    type: git
-    url: https://github.com/PickNikRobotics/pick_ik
-    version: main

--- a/package.xml
+++ b/package.xml
@@ -36,7 +36,6 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>moveit_task_constructor_core</depend>
-  <depend>pick_ik</depend>
 
   <build_depend>eigen</build_depend>
   <build_depend>geometric_shapes</build_depend>


### PR DESCRIPTION
### Description

If people want to use pick_ik, it can still be installed optionally. But it's a bit wasteful to have it be built all the time.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
