### PR TITLE
Re-add `gz_ros2_control` source build

### DIFF
--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -32,3 +32,9 @@ repositories:
     type: git
     url: https://github.com/tylerjw/serial.git
     version: ros2
+  # This package was removed from binaries in the 2025-01-02 Rolling sync.
+  # If/when this is re-added, can remove from this list.
+  gz_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gz_ros2_control.git
+    version: rolling

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -40,3 +40,10 @@ repositories:
     type: git
     url: https://github.com/moveit/moveit_msgs
     version: ros2
+  # This package was removed from binaries in the 2025-01-02 Rolling sync.
+  # If/when this is re-added, can remove from this list.
+  gz_ros2_control:
+    type: git
+    url: https://github.com/ros-controls/gz_ros2_control.git
+    version: rolling
+

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -46,4 +46,3 @@ repositories:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git
     version: rolling
-


### PR DESCRIPTION
### Description

Seems like `ros-rolling-gz-ros2-control` was removed in the latest Rolling 2025-01-02 sync for some reason. So adding this for now.

https://discourse.ros.org/t/new-packages-for-ros-2-rolling-ridley-2025-01-02/41376/2

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
