### PR TITLE
Switch ros2_kortex to Kinova main branch

### DIFF
--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -16,12 +16,10 @@ repositories:
     url: https://github.com/PickNikRobotics/rviz_visual_tools.git
     version: ros2
   # Remove ros2_kortex when rolling binaries are available.
-  # Need to use this fork since ros2_kortex depends on Gazebo classic packages:
-  # https://github.com/Kinovarobotics/ros2_kortex/issues/217
   ros2_kortex:
     type: git
-    url: https://github.com/sea-bass/ros2_kortex.git
-    version: remove-gazebo-classic
+    url: https://github.com/Kinovarobotics/ros2_kortex.git
+    version: main
   # Remove ros2_robotiq_gripper when rolling binaries are available.
   ros2_robotiq_gripper:
     type: git

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -8,12 +8,10 @@ repositories:
     url: https://github.com/moveit/moveit_visual_tools
     version: ros2
   # Remove ros2_kortex when rolling binaries are available.
-  # Need to use this fork since ros2_kortex depends on Gazebo classic packages:
-  # https://github.com/Kinovarobotics/ros2_kortex/issues/217
   ros2_kortex:
     type: git
-    url: https://github.com/sea-bass/ros2_kortex.git
-    version: remove-gazebo-classic
+    url: https://github.com/Kinovarobotics/ros2_kortex.git
+    version: main
   # Remove ros2_robotiq_gripper when rolling binaries are available.
   ros2_robotiq_gripper:
     type: git


### PR DESCRIPTION
### Description

Now that https://github.com/Kinovarobotics/ros2_kortex/pull/228 was merged, we can switch back to Kinova's official repo 🎉 

Tested on `ros2 launch moveit2_tutorials demo.launch.py` and it worked for me.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
