### PR TITLE
Use latest version of doxylink

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ sphinx-tabs
 sphinx-multiversion
 sphinx-rtd-theme
 sphinx-copybutton
-sphinxcontrib-doxylink@git+https://github.com/sea-bass/doxylink.git@fix-parse-tag-file
+sphinxcontrib-doxylink@git+https://github.com/sphinx-contrib/doxylink.git@master


### PR DESCRIPTION
### Description

As described in https://github.com/sphinx-contrib/doxylink/pull/59#issuecomment-2604811415, we should be able to switch to the upstream version of `doxylink` again... thus fully removing a dependency on my personal forks.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
