### PR TITLE
Remove gz_ros2_control source build and add picknik_controllers

### DIFF
--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -30,9 +30,10 @@ repositories:
     type: git
     url: https://github.com/tylerjw/serial.git
     version: ros2
-  # This package was removed from binaries in the 2025-01-02 Rolling sync.
-  # If/when this is re-added, can remove from this list.
-  gz_ros2_control:
+  # This package was removed from binaries in the 2025-02-03 Rolling sync.
+  # If/when https://github.com/PickNikRobotics/picknik_controllers/pull/14 is merged and the package is re-added,
+  # we can remove from this list.
+  picknik_controllers:
     type: git
-    url: https://github.com/ros-controls/gz_ros2_control.git
-    version: rolling
+    url: https://github.com/sea-bass/picknik_controllers.git
+    version: fix-deprecated-realtime-tools-imports

--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -38,9 +38,10 @@ repositories:
     type: git
     url: https://github.com/moveit/moveit_msgs
     version: ros2
-  # This package was removed from binaries in the 2025-01-02 Rolling sync.
-  # If/when this is re-added, can remove from this list.
-  gz_ros2_control:
+  # This package was removed from binaries in the 2025-02-03 Rolling sync.
+  # If/when https://github.com/PickNikRobotics/picknik_controllers/pull/14 is merged and the package is re-added,
+  # we can remove from this list.
+  picknik_controllers:
     type: git
-    url: https://github.com/ros-controls/gz_ros2_control.git
-    version: rolling
+    url: https://github.com/sea-bass/picknik_controllers.git
+    version: fix-deprecated-realtime-tools-imports


### PR DESCRIPTION
### Description

The revolving door of packages booted off Rolling keeps turning...

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
