### PR TITLE
Fix Typo in Trajectory Cache How-To-Guide

### DIFF
--- a/doc/how_to_guides/trajectory_cache/trajectory_cache_tutorial.rst
+++ b/doc/how_to_guides/trajectory_cache/trajectory_cache_tutorial.rst
@@ -322,5 +322,5 @@ For example, you may decide to write your own feature extractor to key the cache
 
 See:
 
-- :moveit_codedir:`package README <moveit_ros/trajectory_cache/include/moveit/trajectory_cache/features/features_interface.hpp>`
-- :moveit_codedir:`package README <moveit_ros/trajectory_cache/include/moveit/trajectory_cache/cache_insert_policies/cache_insert_policy_interface.hpp>`
+- :moveit_codedir:`FeaturesInterface<FeatureSourceT <moveit_ros/trajectory_cache/include/moveit/trajectory_cache/features/features_interface.hpp>`
+- :moveit_codedir:`CacheInsertPolicyInterface <moveit_ros/trajectory_cache/include/moveit/trajectory_cache/cache_insert_policies/cache_insert_policy_interface.hpp>`

--- a/doc/how_to_guides/trajectory_cache/trajectory_cache_tutorial.rst
+++ b/doc/how_to_guides/trajectory_cache/trajectory_cache_tutorial.rst
@@ -312,7 +312,7 @@ Customizable Behavior
 +++++++++++++++++++++
 
 It is possible to extend the cache to key on custom user-defined features, and also to change the cache insertion, sorting, and pruning logic.
-You do this by implementing the features and cache insert policy interfaces, then feeding them into the
+You do this by implementing the features and cache insert policy interfaces, then feeding them into the appropriate cache methods.
 
 For example, you may decide to write your own feature extractor to key the cache, and decide when to insert or prune a cache entry on features such as:
 


### PR DESCRIPTION
I accidentally made a copy-paste typo at the bottom...

Sorry for the noise. @sea-bass