### PR TITLE
Fix two nodes launched with same name of /rivz2

### DIFF
--- a/doc/examples/jupyter_notebook_prototyping/jupyter_notebook_prototyping_tutorial.rst
+++ b/doc/examples/jupyter_notebook_prototyping/jupyter_notebook_prototyping_tutorial.rst
@@ -108,7 +108,7 @@ Once our MoveIt configuration is defined we start the following set of nodes:
                 package="rviz2",
                 executable="rviz2",
                 output="log",
-                arguments=["-d", rviz_config_file, "--ros-args", "--remap", "rviz:__name:=rviz2"],
+                arguments=["-d", rviz_config_file],
                 parameters=[
                         moveit_config.robot_description,
                         moveit_config.robot_description_semantic,

--- a/doc/examples/jupyter_notebook_prototyping/jupyter_notebook_prototyping_tutorial.rst
+++ b/doc/examples/jupyter_notebook_prototyping/jupyter_notebook_prototyping_tutorial.rst
@@ -107,9 +107,8 @@ Once our MoveIt configuration is defined we start the following set of nodes:
         rviz_node = Node(
                 package="rviz2",
                 executable="rviz2",
-                name="rviz2",
                 output="log",
-                arguments=["-d", rviz_config_file],
+                arguments=["-d", rviz_config_file, "--ros-args", "--remap", "rviz:__name:=rviz2"],
                 parameters=[
                         moveit_config.robot_description,
                         moveit_config.robot_description_semantic,

--- a/doc/examples/jupyter_notebook_prototyping/launch/jupyter_notebook_prototyping.launch.py
+++ b/doc/examples/jupyter_notebook_prototyping/launch/jupyter_notebook_prototyping.launch.py
@@ -58,13 +58,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_config_file,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_config_file],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/examples/jupyter_notebook_prototyping/launch/jupyter_notebook_prototyping.launch.py
+++ b/doc/examples/jupyter_notebook_prototyping/launch/jupyter_notebook_prototyping.launch.py
@@ -57,9 +57,14 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config_file],
+        arguments=[
+            "-d",
+            rviz_config_file,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/examples/motion_planning_python_api/launch/motion_planning_python_api_tutorial.launch.py
+++ b/doc/examples/motion_planning_python_api/launch/motion_planning_python_api_tutorial.launch.py
@@ -49,13 +49,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_config_file,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_config_file],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/examples/motion_planning_python_api/launch/motion_planning_python_api_tutorial.launch.py
+++ b/doc/examples/motion_planning_python_api/launch/motion_planning_python_api_tutorial.launch.py
@@ -48,9 +48,14 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config_file],
+        arguments=[
+            "-d",
+            rviz_config_file,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/examples/move_group_interface/launch/move_group.launch.py
+++ b/doc/examples/move_group_interface/launch/move_group.launch.py
@@ -28,9 +28,14 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config_file],
+        arguments=[
+            "-d",
+            rviz_config_file,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/examples/move_group_interface/launch/move_group.launch.py
+++ b/doc/examples/move_group_interface/launch/move_group.launch.py
@@ -29,13 +29,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_config_file,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_config_file],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/examples/moveit_cpp/launch/moveit_cpp_tutorial.launch.py
+++ b/doc/examples/moveit_cpp/launch/moveit_cpp_tutorial.launch.py
@@ -41,13 +41,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_config_file,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_config_file],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/examples/moveit_cpp/launch/moveit_cpp_tutorial.launch.py
+++ b/doc/examples/moveit_cpp/launch/moveit_cpp_tutorial.launch.py
@@ -40,9 +40,14 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config_file],
+        arguments=[
+            "-d",
+            rviz_config_file,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/examples/perception_pipeline/launch/perception_pipeline_demo.launch.py
+++ b/doc/examples/perception_pipeline/launch/perception_pipeline_demo.launch.py
@@ -70,9 +70,8 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config],
+        arguments=["-d", rviz_config, "--ros-args", "--remap", "rviz:__name:=rviz2"],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/examples/perception_pipeline/launch/perception_pipeline_demo.launch.py
+++ b/doc/examples/perception_pipeline/launch/perception_pipeline_demo.launch.py
@@ -71,7 +71,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=["-d", rviz_config, "--ros-args", "--remap", "rviz:__name:=rviz2"],
+        arguments=["-d", rviz_config],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/examples/realtime_servo/launch/pose_tracking_tutorial.launch.py
+++ b/doc/examples/realtime_servo/launch/pose_tracking_tutorial.launch.py
@@ -42,13 +42,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_config_file,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_config_file],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/examples/realtime_servo/launch/pose_tracking_tutorial.launch.py
+++ b/doc/examples/realtime_servo/launch/pose_tracking_tutorial.launch.py
@@ -41,9 +41,14 @@ def generate_launch_description():
     rviz_node = launch_ros.actions.Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config_file],
+        arguments=[
+            "-d",
+            rviz_config_file,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/chomp_planner/launch/chomp_demo.launch.py
+++ b/doc/how_to_guides/chomp_planner/launch/chomp_demo.launch.py
@@ -48,13 +48,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_empty_config,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_empty_config],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,
@@ -67,13 +61,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_full_config,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_full_config],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/chomp_planner/launch/chomp_demo.launch.py
+++ b/doc/how_to_guides/chomp_planner/launch/chomp_demo.launch.py
@@ -47,9 +47,14 @@ def generate_launch_description():
     rviz_node_tutorial = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_empty_config],
+        arguments=[
+            "-d",
+            rviz_empty_config,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,
@@ -61,9 +66,14 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_full_config],
+        arguments=[
+            "-d",
+            rviz_full_config,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/isaac_panda/launch/isaac_demo.launch.py
+++ b/doc/how_to_guides/isaac_panda/launch/isaac_demo.launch.py
@@ -54,13 +54,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_config_file,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_config_file],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/isaac_panda/launch/isaac_demo.launch.py
+++ b/doc/how_to_guides/isaac_panda/launch/isaac_demo.launch.py
@@ -53,9 +53,14 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config_file],
+        arguments=[
+            "-d",
+            rviz_config_file,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/moveit_launch_files/moveit_launch_files_tutorial.rst
+++ b/doc/how_to_guides/moveit_launch_files/moveit_launch_files_tutorial.rst
@@ -89,7 +89,7 @@ The following code uses a launch argument to receive an RViz configuration file 
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=["-d", rviz_config, "--ros-args", "--remap", "rviz:__name:=rviz2"],
+        arguments=["-d", rviz_config],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/moveit_launch_files/moveit_launch_files_tutorial.rst
+++ b/doc/how_to_guides/moveit_launch_files/moveit_launch_files_tutorial.rst
@@ -88,9 +88,8 @@ The following code uses a launch argument to receive an RViz configuration file 
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config],
+        arguments=["-d", rviz_config, "--ros-args", "--remap", "rviz:__name:=rviz2"],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/parallel_planning/launch/parallel_planning_example.launch.py
+++ b/doc/how_to_guides/parallel_planning/launch/parallel_planning_example.launch.py
@@ -120,13 +120,7 @@ def launch_setup(context, *args, **kwargs):
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_config_file,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_config_file],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/parallel_planning/launch/parallel_planning_example.launch.py
+++ b/doc/how_to_guides/parallel_planning/launch/parallel_planning_example.launch.py
@@ -119,9 +119,14 @@ def launch_setup(context, *args, **kwargs):
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config_file],
+        arguments=[
+            "-d",
+            rviz_config_file,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/persistent_scenes_and_states/launch/persistent_scenes_demo.launch.py
+++ b/doc/how_to_guides/persistent_scenes_and_states/launch/persistent_scenes_demo.launch.py
@@ -60,13 +60,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_config_file,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_config_file],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/persistent_scenes_and_states/launch/persistent_scenes_demo.launch.py
+++ b/doc/how_to_guides/persistent_scenes_and_states/launch/persistent_scenes_demo.launch.py
@@ -59,9 +59,14 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config_file],
+        arguments=[
+            "-d",
+            rviz_config_file,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/pick_ik/launch/demo_pick_ik.launch.py
+++ b/doc/how_to_guides/pick_ik/launch/demo_pick_ik.launch.py
@@ -66,7 +66,7 @@ def launch_setup(context, *args, **kwargs):
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=["-d", rviz_config, "--ros-args", "--remap", "rviz:__name:=rviz2"],
+        arguments=["-d", rviz_config],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/pick_ik/launch/demo_pick_ik.launch.py
+++ b/doc/how_to_guides/pick_ik/launch/demo_pick_ik.launch.py
@@ -65,9 +65,8 @@ def launch_setup(context, *args, **kwargs):
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config],
+        arguments=["-d", rviz_config, "--ros-args", "--remap", "rviz:__name:=rviz2"],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/pilz_industrial_motion_planner/launch/pilz_moveit.launch.py
+++ b/doc/how_to_guides/pilz_industrial_motion_planner/launch/pilz_moveit.launch.py
@@ -41,9 +41,14 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config_file],
+        arguments=[
+            "-d",
+            rviz_config_file,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/pilz_industrial_motion_planner/launch/pilz_moveit.launch.py
+++ b/doc/how_to_guides/pilz_industrial_motion_planner/launch/pilz_moveit.launch.py
@@ -42,13 +42,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_config_file,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_config_file],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/trajectory_cache/launch/trajectory_cache_move_group.launch.py
+++ b/doc/how_to_guides/trajectory_cache/launch/trajectory_cache_move_group.launch.py
@@ -41,9 +41,14 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config_file],
+        arguments=[
+            "-d",
+            rviz_config_file,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/trajectory_cache/launch/trajectory_cache_move_group.launch.py
+++ b/doc/how_to_guides/trajectory_cache/launch/trajectory_cache_move_group.launch.py
@@ -42,13 +42,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_config_file,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_config_file],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/using_ompl_constrained_planning/launch/ompl_constrained_planning.launch.py
+++ b/doc/how_to_guides/using_ompl_constrained_planning/launch/ompl_constrained_planning.launch.py
@@ -58,13 +58,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_config_file,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_config_file],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/how_to_guides/using_ompl_constrained_planning/launch/ompl_constrained_planning.launch.py
+++ b/doc/how_to_guides/using_ompl_constrained_planning/launch/ompl_constrained_planning.launch.py
@@ -57,9 +57,14 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config_file],
+        arguments=[
+            "-d",
+            rviz_config_file,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/launch/mtc_demo.launch.py
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/launch/mtc_demo.launch.py
@@ -41,9 +41,14 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config_file],
+        arguments=[
+            "-d",
+            rviz_config_file,
+            "--ros-args",
+            "--remap",
+            "rviz:__name:=rviz2",
+        ],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/launch/mtc_demo.launch.py
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/launch/mtc_demo.launch.py
@@ -42,13 +42,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=[
-            "-d",
-            rviz_config_file,
-            "--ros-args",
-            "--remap",
-            "rviz:__name:=rviz2",
-        ],
+        arguments=["-d", rviz_config_file],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -58,9 +58,8 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config],
+        arguments=["-d", rviz_config, "--ros-args", "--remap", "rviz:__name:=rviz2"],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,

--- a/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
+++ b/doc/tutorials/quickstart_in_rviz/launch/demo.launch.py
@@ -59,7 +59,7 @@ def generate_launch_description():
         package="rviz2",
         executable="rviz2",
         output="log",
-        arguments=["-d", rviz_config, "--ros-args", "--remap", "rviz:__name:=rviz2"],
+        arguments=["-d", rviz_config],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,


### PR DESCRIPTION
### Description

Address https://github.com/moveit/moveit2_tutorials/issues/991 where two nodes are launched with same name `rviz2`. The fix is to remove node name attribute when launching `rviz2`. 

### Testing 
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Validated the updated Python files are launched successfully and there is no duplicate `rviz2` node. 
