### PR TITLE
Add note about older branches in pick_and_place_with_moveit_task_constructor.rst

### DIFF
--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
@@ -19,7 +19,12 @@ Download MoveIt Task Constructor
 Move into your colcon workspace and pull the MoveIt Task Constructor source: ::
 
     cd ~/ws_moveit2/src
-    git clone https://github.com/ros-planning/moveit_task_constructor.git -b $ROS_DISTRO
+    git clone https://github.com/ros-planning/moveit_task_constructor.git -b ros2
+
+Attention: If you are ``ros2 humble`` user, you should use ``humble`` branch to clone a correct version code: ::
+
+    cd ~/ws_moveit2/src
+    git clone https://github.com/ros-planning/moveit_task_constructor.git -b humble
 
 Create a New Package
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
@@ -23,7 +23,6 @@ Move into your colcon workspace and pull the MoveIt Task Constructor source: ::
 
 Note: If you are using ROS 2 Humble, you should instead clone the ``humble`` branch of the repository: ::
 
-    cd ~/ws_moveit2/src
     git clone https://github.com/ros-planning/moveit_task_constructor.git -b humble
 
 Create a New Package

--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
@@ -21,7 +21,7 @@ Move into your colcon workspace and pull the MoveIt Task Constructor source: ::
     cd ~/ws_moveit2/src
     git clone https://github.com/ros-planning/moveit_task_constructor.git -b ros2
 
-Attention: If you are ``ros2 humble`` user, you should use ``humble`` branch to clone a correct version code: ::
+Note: If you are using ROS 2 Humble, you should instead clone the ``humble`` branch of the repository: ::
 
     cd ~/ws_moveit2/src
     git clone https://github.com/ros-planning/moveit_task_constructor.git -b humble

--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
@@ -19,7 +19,7 @@ Download MoveIt Task Constructor
 Move into your colcon workspace and pull the MoveIt Task Constructor source: ::
 
     cd ~/ws_moveit2/src
-    git clone https://github.com/ros-planning/moveit_task_constructor.git -b ros2
+    git clone https://github.com/ros-planning/moveit_task_constructor.git -b $ROS_DISTRO
 
 Create a New Package
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I use Ubuntu 22.04 and ros2 humble to run the tutorial. When I clone moveit_task_constructor and build, I face many problem because my moveit is humble version. Therefore I look up the tutorial and find this problem.

### Description

change branch from  ``ros2`` to ``$ROS_DISTRO``

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
