### PR TITLE
Remove Google Analytics ID

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -112,8 +112,6 @@ html_theme_options = {
     "collapse_navigation": True,
     "sticky_navigation": True,
     "navigation_depth": -1,
-    # This is the Google Analytics account used by moveit.ros.org, not picknik.ai
-    "analytics_id": "UA-108532843-1",
     # Only display the logo image, do not display the project name at the top of the sidebar
     "logo_only": True,
 }


### PR DESCRIPTION
### Description

This was causing build errors on a recent PR, and also who cares about this?

Error:

```
Warning, treated as error:
The analytics_id option is deprecated, use the sphinxcontrib-googleanalytics extension instead.
```

I feel like instead of figuring this out or pinning back the Sphinx version, it's best to reMoveIt!

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
