### PR TITLE
Rolling: Add OMPL config to moveit_cpp.yaml

### DIFF
--- a/doc/examples/moveit_cpp/config/moveit_cpp.yaml
+++ b/doc/examples/moveit_cpp/config/moveit_cpp.yaml
@@ -12,6 +12,19 @@ planning_pipelines:
   pipeline_names: ["ompl"]
 ompl:
   planning_plugin: ompl_interface/OMPLPlanner
+  request_adapters: >-
+    default_planner_request_adapters/AddTimeOptimalParameterization
+    default_planner_request_adapters/FixWorkspaceBounds
+    default_planner_request_adapters/FixStartStateBounds
+    default_planner_request_adapters/FixStartStateCollision
+    default_planner_request_adapters/FixStartStatePathConstraints
+  planner_configs:
+    PRMstarkConfigDefault:
+      type: geometric::PRMstar
+  # Define planner(s) for each move_group
+  panda_arm:
+    planner_configs:
+      - PRMstarkConfigDefault
   # Add additional planning pipeline config here
 plan_request_params:
   planning_attempts: 1

--- a/doc/examples/moveit_cpp/config/moveit_cpp.yaml
+++ b/doc/examples/moveit_cpp/config/moveit_cpp.yaml
@@ -10,6 +10,8 @@ planning_scene_monitor_options:
 planning_pipelines:
   #namespace: "moveit_cpp"  # optional, default is ~
   pipeline_names: ["ompl"]
+ompl:
+  planning_plugin: ompl_interface/OMPLPlanner
 
 plan_request_params:
   planning_attempts: 1

--- a/doc/examples/moveit_cpp/config/moveit_cpp.yaml
+++ b/doc/examples/moveit_cpp/config/moveit_cpp.yaml
@@ -12,7 +12,7 @@ planning_pipelines:
   pipeline_names: ["ompl"]
 ompl:
   planning_plugin: ompl_interface/OMPLPlanner
-
+  # Add additional planning pipeline config here
 plan_request_params:
   planning_attempts: 1
   planning_pipeline: ompl

--- a/doc/examples/moveit_cpp/config/moveit_cpp.yaml
+++ b/doc/examples/moveit_cpp/config/moveit_cpp.yaml
@@ -12,12 +12,19 @@ planning_pipelines:
   pipeline_names: ["ompl"]
 ompl:
   planning_plugin: ompl_interface/OMPLPlanner
-  request_adapters: >-
-    default_planner_request_adapters/AddTimeOptimalParameterization
-    default_planner_request_adapters/FixWorkspaceBounds
-    default_planner_request_adapters/FixStartStateBounds
-    default_planner_request_adapters/FixStartStateCollision
-    default_planner_request_adapters/FixStartStatePathConstraints
+  planning_plugins:
+    - ompl_interface/OMPLPlanner
+  # To optionally use Ruckig for jerk-limited smoothing, add this line to the request adapters below
+  # default_planning_request_adapters/AddRuckigTrajectorySmoothing
+  request_adapters:
+    - default_planning_request_adapters/ResolveConstraintFrames
+    - default_planning_request_adapters/ValidateWorkspaceBounds
+    - default_planning_request_adapters/CheckStartStateBounds
+    - default_planning_request_adapters/CheckStartStateCollision
+  response_adapters:
+    - default_planning_response_adapters/AddTimeOptimalParameterization
+    - default_planning_response_adapters/ValidateSolution
+    - default_planning_response_adapters/DisplayMotionPath
   planner_configs:
     PRMstarkConfigDefault:
       type: geometric::PRMstar


### PR DESCRIPTION
It took me way too long to figure out why `moveit_cpp` was using the CHOMP planning pipeline. It's because `ompl` pipeline wasn't configured here, so MoveIt defaults to the first planning pipeline in the list.

(I've only tested this on Humble, hopefully it hasn't changed since then.)
