### PR TITLE
Remove gripper_controllers dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -47,7 +47,6 @@
   <!-- <exec_depend>franka_description</exec_depend> -->
   <!-- <exec_depend>moveit_commander</exec_depend> -->
   <exec_depend>controller_manager</exec_depend>
-  <exec_depend>gripper_controllers</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>


### PR DESCRIPTION
The package got removed upstream in https://github.com/ros-controls/ros2_controllers/pull/1652. Find_packageing this on Kilted or Rolling will lead to errors from the next sync on.