### PR TITLE
Update how_to_generate_api_doxygen_locally.rst to match generated index.html file location

### DIFF
--- a/doc/how_to_guides/how_to_generate_api_doxygen_locally.rst
+++ b/doc/how_to_guides/how_to_generate_api_doxygen_locally.rst
@@ -32,4 +32,4 @@ Steps
 
 .. code-block:: bash
 
-  firefox ~/docs/index.html
+  firefox ~/docs/html/index.html


### PR DESCRIPTION
### Description

The [how to guide](https://moveit.picknik.ai/main/doc/how_to_guides/how_to_generate_api_doxygen_locally.html) for generating the doxygen documentation said to open `~/docs/index.html`, which does not exist. The files generated by the commands in the how to guide are actually located in `~/docs/html/index.html`. That is all.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
