### PR TITLE
Fix tf2*.h compile deprecations

### DIFF
--- a/doc/examples/trajopt_planner/src/trajopt_example.cpp
+++ b/doc/examples/trajopt_planner/src/trajopt_example.cpp
@@ -17,7 +17,6 @@
 #include <moveit_msgs/PlanningScene.h>
 
 #include <geometry_msgs/TransformStamped.h>
-
 #include <tf2/utils.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_ros/transform_listener.hpp>

--- a/doc/examples/trajopt_planner/src/trajopt_example.cpp
+++ b/doc/examples/trajopt_planner/src/trajopt_example.cpp
@@ -20,13 +20,13 @@
 
 // TODO(mosfet80): remove else after EOL galactic
 #if __has_include(<tf2/utils.hpp>)
-   #include <tf2/utils.hpp>
-   #include <tf2_eigen/tf2_eigen.hpp>
-   #include <tf2_ros/transform_listener.hpp>
+#include <tf2/utils.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <tf2_ros/transform_listener.hpp>
 #else
-   #include <tf2/utils.h>
-   #include <tf2_eigen/tf2_eigen.h>
-   #include <tf2_ros/transform_listener.h>
+#include <tf2/utils.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_ros/transform_listener.h>
 #endif
 
 

--- a/doc/examples/trajopt_planner/src/trajopt_example.cpp
+++ b/doc/examples/trajopt_planner/src/trajopt_example.cpp
@@ -17,9 +17,19 @@
 #include <moveit_msgs/PlanningScene.h>
 
 #include <geometry_msgs/TransformStamped.h>
-#include <tf2/utils.hpp>
-#include <tf2_eigen/tf2_eigen.hpp>
-#include <tf2_ros/transform_listener.hpp>
+
+// TODO(mosfet80): remove else after EOL galactic
+#if __has_include(<tf2/utils.hpp>)
+   #include <tf2/utils.hpp>
+   #include <tf2_eigen/tf2_eigen.hpp>
+   #include <tf2_ros/transform_listener.hpp>
+#else
+   #include <tf2/utils.h>
+   #include <tf2_eigen/tf2_eigen.h>
+   #include <tf2_ros/transform_listener.h>
+#endif
+
+
 
 /* Author: Omid Heidari
    Desc: This file is a test for using trajopt in MoveIt. The goal is to make different types of constraints in

--- a/doc/examples/trajopt_planner/src/trajopt_example.cpp
+++ b/doc/examples/trajopt_planner/src/trajopt_example.cpp
@@ -18,16 +18,9 @@
 
 #include <geometry_msgs/TransformStamped.h>
 
-// TODO(mosfet80): remove else after EOL galactic
-#if __has_include(<tf2/utils.hpp>)
 #include <tf2/utils.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_ros/transform_listener.hpp>
-#else
-#include <tf2/utils.h>
-#include <tf2_eigen/tf2_eigen.h>
-#include <tf2_ros/transform_listener.h>
-#endif
 
 /* Author: Omid Heidari
    Desc: This file is a test for using trajopt in MoveIt. The goal is to make different types of constraints in

--- a/doc/examples/trajopt_planner/src/trajopt_example.cpp
+++ b/doc/examples/trajopt_planner/src/trajopt_example.cpp
@@ -29,8 +29,6 @@
 #include <tf2_ros/transform_listener.h>
 #endif
 
-
-
 /* Author: Omid Heidari
    Desc: This file is a test for using trajopt in MoveIt. The goal is to make different types of constraints in
    MotionPlanRequest and visualize the result calculated using the trajopt planner.

--- a/doc/examples/trajopt_planner/src/trajopt_example.cpp
+++ b/doc/examples/trajopt_planner/src/trajopt_example.cpp
@@ -17,9 +17,9 @@
 #include <moveit_msgs/PlanningScene.h>
 
 #include <geometry_msgs/TransformStamped.h>
-#include <tf2/utils.h>
-#include <tf2_eigen/tf2_eigen.h>
-#include <tf2_ros/transform_listener.h>
+#include <tf2/utils.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <tf2_ros/transform_listener.hpp>
 
 /* Author: Omid Heidari
    Desc: This file is a test for using trajopt in MoveIt. The goal is to make different types of constraints in


### PR DESCRIPTION


### Description

using tf2 *.h hesders is deprecated ->switch to *.hpp


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TF2 header references in the trajectory optimization example.
  * No user-facing behavior or runtime functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->