### PR TITLE
Remove moveit2_tutorials.repos entries now available in Rolling

### DIFF
--- a/moveit2_tutorials.repos
+++ b/moveit2_tutorials.repos
@@ -7,21 +7,6 @@ repositories:
     type: git
     url: https://github.com/moveit/moveit_visual_tools
     version: ros2
-  # Remove ros2_kortex when rolling binaries are available.
-  ros2_kortex:
-    type: git
-    url: https://github.com/Kinovarobotics/ros2_kortex.git
-    version: main
-  # Remove ros2_robotiq_gripper when rolling binaries are available.
-  ros2_robotiq_gripper:
-    type: git
-    url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
-    version: main
-  # Serial is a dependency of ros2_robotiq_gripper. Remove when ros2_robotiq_gripper binaries are available.
-  serial:
-    type: git
-    url: https://github.com/tylerjw/serial.git
-    version: ros2
   rviz_visual_tools:
     type: git
     url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION

### Description

This plus https://github.com/PickNikRobotics/rviz_visual_tools/pull/284 will fix moveit2_tutorial rolling CI job because the ros2_kortex source checkout was trying to use the gripper_controllers removed form Kilted and Rolling and not parallel_gripper_controller (see https://github.com/Kinovarobotics/ros2_kortex/issues/294)

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete repository dependencies from the MoveIt 2 tutorials configuration.
  * Simplified setup by eliminating unused external repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->