### PR TITLE
Fix UB from using uninitialised grasp_frame_transform

### DIFF
--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
@@ -696,7 +696,7 @@ Before we compute inverse kinematics for the poses generated above, we first nee
 
 .. code-block:: c++
 
-          Eigen::Isometry3d grasp_frame_transform;
+          Eigen::Isometry3d grasp_frame_transform = Eigen::Isometry3d::Identity();
           Eigen::Quaterniond q = Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitX()) *
                                 Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitY()) *
                                 Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitZ());


### PR DESCRIPTION
### Description

Please explain the changes you made, including a reference to the related issue if applicable

I initialised `grasp_frame_transform` such that when it is used during planning, no values of `grasp_frame_transform` are left uninitialised. This was previously the case with `grasp_frame_transform.translation().x()` and `grasp_frame_transform.translation().y()`.

Related issue: [#1079](https://github.com/moveit/moveit2_tutorials/issues/1079)

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pick-and-place tutorial reliability by initializing the grasp frame transform before applying adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->