### PR TITLE
Correct naming and order of planning response adapters

### DIFF
--- a/doc/examples/time_parameterization/time_parameterization_tutorial.rst
+++ b/doc/examples/time_parameterization/time_parameterization_tutorial.rst
@@ -30,11 +30,11 @@ A time parameterization algorithm such as TOTG calculates velocities and acceler
 
 To apply the Ruckig smoothing algorithm, jerk limits should be defined in a ``joint_limits.yaml`` file. If you do not specify a jerk limit for any joint, a reasonable default will be applied and a warning printed.
 
-Finally, add the Ruckig smoothing algorithm to the list of planning request adapters (typically in ``ompl_planning.yaml``). The Ruckig smoothing algorithm should run last, so put it at the top of list:
+Finally, add the Ruckig smoothing algorithm to the list of planning response adapters (typically in ``ompl_planning.yaml``). The Ruckig smoothing algorithm should run after AddTimeOptimalParameterization, so put it below AddTimeOptimalParameterization in the list:
 
 .. code-block:: yaml
 
       response_adapters:
-        - default_planning_request_adapters/AddRuckigTrajectorySmoothing
-        - default_planning_request_adapters/AddTimeOptimalParameterization
+        - default_planning_response_adapters/AddTimeOptimalParameterization
+        - default_planning_response_adapters/AddRuckigTrajectorySmoothing
         ...


### PR DESCRIPTION
### Description

The AddRuckigTrajectorySmoothing was mentioned as a request adapter, even though it is a response adapter. The order of  response_adapters in the ompl_planning.yaml needs to be AddTimeOptimalParameterization first, then AddRuckigTrajectorySmoothing, which will correctly execute them in the order of (1) AddTimeOptimalParameterization, (2) AddRuckigTrajectorySmoothing.

I changed the order of the response adapters and correctly named them as response, not request adapters.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
