### PR TITLE
Initialize grasp_frame_transform to Identity in MTC tutorial

### DIFF
--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
@@ -696,7 +696,7 @@ Before we compute inverse kinematics for the poses generated above, we first nee
 
 .. code-block:: c++
 
-          Eigen::Isometry3d grasp_frame_transform;
+          Eigen::Isometry3d grasp_frame_transform = Eigen::Isometry3d::Identity();
           Eigen::Quaterniond q = Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitX()) *
                                 Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitY()) *
                                 Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitZ());

--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/src/mtc_node.cpp
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/src/mtc_node.cpp
@@ -188,7 +188,7 @@ mtc::Task MTCTaskNode::createTask()
       stage->setMonitoredStage(current_state_ptr);  // Hook into current state
 
       // This is the transform from the object frame to the end-effector frame
-      Eigen::Isometry3d grasp_frame_transform;
+      Eigen::Isometry3d grasp_frame_transform = Eigen::Isometry3d::Identity();
       Eigen::Quaterniond q = Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitX()) *
                              Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitY()) *
                              Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitZ());


### PR DESCRIPTION
## Summary

- Fixes #1079
- Initializes `grasp_frame_transform` to `Eigen::Isometry3d::Identity()` in both the tutorial source code and the RST code block

## What changed

Two files:
- `src/mtc_node.cpp` (line 191)
- `pick_and_place_with_moveit_task_constructor.rst` (line 699)

```cpp
// Before (uninitialized, translation component contains garbage values)
Eigen::Isometry3d grasp_frame_transform;

// After
Eigen::Isometry3d grasp_frame_transform = Eigen::Isometry3d::Identity();
```

The original code set rotation via quaternion but never initialized the translation. `Identity()` zeroes the translation and sets rotation to identity before the quaternion assignment overwrites the rotation.

## Test plan

- [ ] Tutorial code compiles
- [ ] RST code block matches source