### PR TITLE
fix broken codedir link in perception_pipeline tutorial

### DIFF
--- a/doc/examples/perception_pipeline/perception_pipeline_tutorial.rst
+++ b/doc/examples/perception_pipeline/perception_pipeline_tutorial.rst
@@ -154,7 +154,7 @@ In Shell 4: ::
 
     ros2 bag play -r 5 <your_bag_file> --loop
 
-:codedir:`perception_pipeline_demo.launch.py <examples/perception_pipeline/launch/perception_pipeline_demo.launch.py>` is similar to :codedir:`demo.launch.py </doc/tutorials/quickstart_in_rviz/launch/demo.launch.py>` inside :doc:`MoveIt Quickstart in RViz </doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial>` except a couple of details. For ``perception_pipeline_demo.launch.py``, following lines is added to ``moveit_config``.
+:codedir:`perception_pipeline_demo.launch.py <examples/perception_pipeline/launch/perception_pipeline_demo.launch.py>` is similar to :codedir:`demo.launch.py <tutorials/quickstart_in_rviz/launch/demo.launch.py>` inside :doc:`MoveIt Quickstart in RViz </doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial>` except a couple of details. For ``perception_pipeline_demo.launch.py``, following lines is added to ``moveit_config``.
 
 You can find these additional lines in line 51, 52 and 53 inside ``perception_pipeline_demo.launch.py``: ::
 


### PR DESCRIPTION
Closes #1062

The `:codedir:` reference to `demo.launch.py` had a leading `/doc/` prefix which produces a double-slash URL and a 404. Fixed to match the working pattern used elsewhere in the tutorials (e.g. `moveit_launch_files_tutorial.rst`).

Before: `` </doc/tutorials/quickstart_in_rviz/launch/demo.launch.py> ``
After:  `` <tutorials/quickstart_in_rviz/launch/demo.launch.py> ``

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the RViz Quickstart tutorial link to point to the corrected documentation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->