### PR TITLE
fix: `ament_target_dependencies()` deprecation

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -61,7 +61,7 @@ RUN --mount=type=cache,target=/root/.ccache/ \
     # Enable ccache
     . "/opt/ros/${ROS_DISTRO}/setup.sh" &&\
     . "install/setup.sh" &&\
-    sudo apt update && rosdep install -r --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y && \
+    sudo apt update && rosdep update && rosdep install -r --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y && \
     colcon build \
         --cmake-args -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                      -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/.github/upstream.repos
+++ b/.github/upstream.repos
@@ -30,3 +30,8 @@ repositories:
     type: git
     url: https://github.com/tylerjw/serial.git
     version: ros2
+  # picknik_controllers, which is removed for rolling in https://github.com/moveit/moveit2_tutorials/pull/1104, is a dependency of ros2_kortex. Remove when rolling binaries are available.
+  picknik_controllers:
+    type: git
+    url: https://github.com/PickNikRobotics/picknik_controllers.git
+    version: 0.0.4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
 
     env:
       DOCKER_IMAGE: moveit/moveit2:${{ matrix.env.IMAGE }}
+      BEFORE_INIT: git config --global --add safe.directory '*'
       UPSTREAM_WORKSPACE: .github/upstream.repos
       AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
       BEFORE_BUILD_TARGET_WORKSPACE: set +u && if [ -f ~/ws_moveit/install/setup.bash ]; then source ~/ws_moveit/install/setup.bash; fi && set -u

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,11 +35,11 @@ jobs:
     name: ${{ matrix.env.IMAGE }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: cache upstream_ws
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           save-always: true
           path: ${{ env.BASEDIR }}/upstream_ws
@@ -49,7 +49,7 @@ jobs:
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: cache target_ws
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           save-always: true
           path: ${{ env.BASEDIR }}/target_ws
@@ -57,7 +57,7 @@ jobs:
           restore-keys: |
             target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
       - name: cache ccache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           save-always: true
           path: ${{ env.CCACHE_DIR }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: cache upstream_ws
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         with:
           save-always: true
           path: ${{ env.BASEDIR }}/upstream_ws
@@ -49,7 +49,7 @@ jobs:
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: cache target_ws
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         with:
           save-always: true
           path: ${{ env.BASEDIR }}/target_ws
@@ -57,7 +57,7 @@ jobs:
           restore-keys: |
             target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
       - name: cache ccache
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         with:
           save-always: true
           path: ${{ env.CCACHE_DIR }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,11 +35,11 @@ jobs:
     name: ${{ matrix.env.IMAGE }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: cache upstream_ws
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           save-always: true
           path: ${{ env.BASEDIR }}/upstream_ws
@@ -49,7 +49,7 @@ jobs:
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: cache target_ws
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           save-always: true
           path: ${{ env.BASEDIR }}/target_ws
@@ -57,7 +57,7 @@ jobs:
           restore-keys: |
             target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
       - name: cache ccache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           save-always: true
           path: ${{ env.CCACHE_DIR }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,22 +18,31 @@ on:
 jobs:
   default:
     strategy:
+      fail-fast: false
       matrix:
         env:
+          - IMAGE: jazzy-release
+          - IMAGE: main-jazzy-tutorial-source
           - IMAGE: rolling-source
+        include:
+          - env:
+              IMAGE: rolling-source
+            continue-on-error: true
+
+    continue-on-error: ${{ matrix.continue-on-error || false }}
 
     env:
       DOCKER_IMAGE: moveit/moveit2:${{ matrix.env.IMAGE }}
       UPSTREAM_WORKSPACE: .github/upstream.repos
       AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
-      AFTER_SETUP_UPSTREAM_WORKSPACE_EMBED: set +u && source ~/ws_moveit/install/setup.bash && set - u
+      BEFORE_BUILD_TARGET_WORKSPACE: set +u && if [ -f ~/ws_moveit/install/setup.bash ]; then source ~/ws_moveit/install/setup.bash; fi && set -u
       TARGET_CMAKE_ARGS: -DCMAKE_BUILD_TYPE=Release
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       BASEDIR: ${{ github.workspace }}/.work
       CACHE_PREFIX: ${{ matrix.env.IMAGE }}
 
     name: ${{ matrix.env.IMAGE }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     container:
       image: moveit/moveit2:rolling-source
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install Python dependencies
       shell: bash
@@ -59,7 +59,7 @@ jobs:
     container:
       image: ${{ matrix.container }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Python dependencies
       shell: bash
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: upload_site_artifacts
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,23 +1,20 @@
 # This is a format job. Pre-commit has a first-party GitHub action, so we use
 # that: https://github.com/pre-commit/action
 
-name: Format
+name: Formatting (pre-commit)
 
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     branches:
       - main
-      - humble
-
-permissions:
-  contents: read # to fetch code (actions/checkout)
 
 jobs:
   pre-commit:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -26,3 +23,9 @@ jobs:
     - name: Install clang-format-14
       run: sudo apt-get install clang-format-14
     - uses: pre-commit/action@v3.0.1
+      id: precommit
+    - name: Upload pre-commit changes
+      if: failure() && steps.precommit.outcome == 'failure'
+      uses: rhaschke/upload-git-patch-action@main
+      with:
+        name: pre-commit

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.10'
     - name: Install clang-format-14

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
     name: Format
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - uses: actions/setup-python@v6
       with:
         python-version: '3.10'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(moveit2_tutorials)
 
 # Common cmake code applied to all moveit packages
 find_package(moveit_common REQUIRED)
+find_package(OpenSSL REQUIRED)
+
 moveit_package()
 
 set(THIS_PACKAGE_INCLUDE_DIRS
@@ -20,14 +22,14 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   moveit_ros_planning
   moveit_ros_planning_interface
   moveit_ros_trajectory_cache
-  moveit_servo
-  moveit_task_constructor_core
-  moveit_visual_tools
+ # moveit_servo
+ # moveit_task_constructor_core
+ # moveit_visual_tools
   pluginlib
   rclcpp
   rclcpp_action
-  rviz_visual_tools
-  tf2_geometry_msgs
+#  rviz_visual_tools
+#  tf2_geometry_msgs
   tf2_geometry_msgs
   tf2_ros
   warehouse_ros_sqlite
@@ -77,9 +79,6 @@ add_subdirectory(doc/tutorials/pick_and_place_with_moveit_task_constructor)
 add_subdirectory(doc/tutorials/quickstart_in_rviz)
 add_subdirectory(doc/how_to_guides/pick_ik)
 
-ament_export_dependencies(
-  ${THIS_PACKAGE_INCLUDE_DEPENDS}
-)
 
 ament_export_include_directories(include)
 

--- a/doc/examples/bullet_collision_checker/CMakeLists.txt
+++ b/doc/examples/bullet_collision_checker/CMakeLists.txt
@@ -4,10 +4,4 @@ add_executable(bullet_collision_checker_tutorial
 target_link_libraries(bullet_collision_checker_tutorial
     ${interactive_markers_LIBRARIES}
     interactivity_utils
-    ${catkin_LIBRARIES}
     ${Boost_LIBRARIES})
-
-install(TARGETS bullet_collision_checker_tutorial
-    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-
-install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/doc/examples/collision_environments/CMakeLists.txt
+++ b/doc/examples/collision_environments/CMakeLists.txt
@@ -1,9 +1,9 @@
+
 add_executable(collision_scene_example
     src/collision_scene_example.cpp)
 target_include_directories(collision_scene_example
     PUBLIC include)
-ament_target_dependencies(collision_scene_example
-    ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(collision_scene_example PUBLIC rclcpp::rclcpp moveit_ros_planning_interface::moveit_move_group_interface)
 
 install(TARGETS collision_scene_example
     ARCHIVE DESTINATION lib

--- a/doc/examples/creating_moveit_plugins/lerp_motion_planner/CMakeLists.txt
+++ b/doc/examples/creating_moveit_plugins/lerp_motion_planner/CMakeLists.txt
@@ -1,13 +1,11 @@
 include_directories(include)
 include_directories(
   SYSTEM
-  ${catkin_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
 )
 
 add_executable(lerp_example  src/lerp_example.cpp)
 target_link_libraries(lerp_example
-  ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
 )
 
@@ -17,39 +15,8 @@ add_library(moveit_lerp_planner_plugin
   src/lerp_interface.cpp
   src/lerp_planning_context.cpp)
 set_target_properties(moveit_lerp_planner_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(moveit_lerp_planner_plugin ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(moveit_lerp_planner_plugin  ${Boost_LIBRARIES})
 
 #############
 ## Install ##
 #############
-
-# Mark executables and/or libraries for installation
-install(
-  TARGETS
-    moveit_lerp_planner_plugin
-  ARCHIVE DESTINATION
-    ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION
-    ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION
-    ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-# Mark cpp header files for installation
-install(
-  DIRECTORY
-    include
-  DESTINATION
-    ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
-
-# Mark roslaunch files for installation
-install(
-  DIRECTORY
-    launch
-  DESTINATION
-    ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
-#catkin_lint ignore uninstalled_plugin
-install(FILES lerp_interface_plugin_description.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/doc/creating_moveit_plugins/lerp_motion_planner/)

--- a/doc/examples/examples.rst
+++ b/doc/examples/examples.rst
@@ -51,7 +51,7 @@ The MoveIt Python API binds a subset of the C++ API. The Python API is useful fo
 
 Integration with a New Robot
 ----------------------------
-Before attempting to integrate a new robot with MoveIt 2, check whether your robot has already been set up (see the `list of robots running MoveIt <http://moveit.ros.org/robots/>`_). Otherwise, follow the tutorials in this section to integrate your robot with MoveIt.
+Before attempting to integrate a new robot with MoveIt 2, check whether your robot has already been set up (see the `list of robots running MoveIt <https://moveit.ai/robots/>`_). Otherwise, follow the tutorials in this section to integrate your robot with MoveIt.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/examples/interactivity/CMakeLists.txt
+++ b/doc/examples/interactivity/CMakeLists.txt
@@ -6,25 +6,6 @@ add_library(${INTERACTIVITY_LIB_NAME}
   src/pose_string.cpp
 )
 
-# add_executable(interactivity_tutorial
-  # src/interactivity_tutorial.cpp
-  # src/interactive_robot.cpp
-  # src/imarker.cpp
-  # src/pose_string.cpp
-# )
-# target_link_libraries(interactivity_tutorial
-  # ${catkin_LIBRARIES}
-  # ${Boost_LIBRARIES}
-  # ${interactive_markers_LIBRARIES}
-# )
-#
-# add_executable(attached_body_tutorial
-  # src/attached_body_tutorial.cpp
-  # src/interactive_robot.cpp
-  # src/imarker.cpp
-  # src/pose_string.cpp
-# )
-
 target_link_libraries(
   ${INTERACTIVITY_LIB_NAME}
   ${catkin_LIBRARIES}

--- a/doc/examples/motion_planning_api/CMakeLists.txt
+++ b/doc/examples/motion_planning_api/CMakeLists.txt
@@ -1,9 +1,17 @@
+find_package(graph_msgs REQUIRED)
+find_package(moveit_msgs REQUIRED)
+find_package(moveit_ros_planning REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(rviz_visual_tools REQUIRED)
 add_executable(motion_planning_api_tutorial
     src/motion_planning_api_tutorial.cpp)
 target_include_directories(motion_planning_api_tutorial
   PUBLIC include)
-ament_target_dependencies(motion_planning_api_tutorial
-  ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(motion_planning_api_tutorial PUBLIC
+${graph_msgs_TARGETS}
+pluginlib::pluginlib moveit_ros_planning::moveit_robot_model_loader moveit_visual_tools::moveit_visual_tools
+moveit_ros_planning_interface::moveit_move_group_interface
+)
 
 install(TARGETS motion_planning_api_tutorial
   DESTINATION lib/${PROJECT_NAME}

--- a/doc/examples/motion_planning_pipeline/CMakeLists.txt
+++ b/doc/examples/motion_planning_pipeline/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(graph_msgs REQUIRED)
+find_package(moveit_ros_planning REQUIRED)
 find_package(moveit_visual_tools REQUIRED)
 find_package(rviz_visual_tools REQUIRED)
 
@@ -7,9 +8,15 @@ add_executable(motion_planning_pipeline_tutorial
 target_include_directories(motion_planning_pipeline_tutorial
     PUBLIC include)
 target_link_libraries(motion_planning_pipeline_tutorial PUBLIC
-${graph_msgs_TARGETS}
-pluginlib::pluginlib moveit_ros_planning::moveit_robot_model_loader
-moveit_visual_tools::moveit_visual_tools rviz_visual_tools::rviz_visual_tools)
+  ${graph_msgs_TARGETS}
+  rclcpp::rclcpp
+  pluginlib::pluginlib
+  moveit_ros_planning::moveit_robot_model_loader
+  moveit_ros_planning::moveit_planning_pipeline
+  moveit_ros_planning::moveit_planning_scene_monitor
+  moveit_visual_tools::moveit_visual_tools
+  rviz_visual_tools::rviz_visual_tools
+)
 
 install(TARGETS motion_planning_pipeline_tutorial
     DESTINATION lib/${PROJECT_NAME}

--- a/doc/examples/motion_planning_pipeline/CMakeLists.txt
+++ b/doc/examples/motion_planning_pipeline/CMakeLists.txt
@@ -1,9 +1,15 @@
+find_package(graph_msgs REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(rviz_visual_tools REQUIRED)
+
 add_executable(motion_planning_pipeline_tutorial
     src/motion_planning_pipeline_tutorial.cpp)
 target_include_directories(motion_planning_pipeline_tutorial
     PUBLIC include)
-ament_target_dependencies(motion_planning_pipeline_tutorial
-    ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(motion_planning_pipeline_tutorial PUBLIC
+${graph_msgs_TARGETS}
+pluginlib::pluginlib moveit_ros_planning::moveit_robot_model_loader
+moveit_visual_tools::moveit_visual_tools rviz_visual_tools::rviz_visual_tools)
 
 install(TARGETS motion_planning_pipeline_tutorial
     DESTINATION lib/${PROJECT_NAME}

--- a/doc/examples/motion_planning_python_api/CMakeLists.txt
+++ b/doc/examples/motion_planning_python_api/CMakeLists.txt
@@ -1,3 +1,7 @@
+find_package(graph_msgs REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(rviz_visual_tools REQUIRED)
+
 install(PROGRAMS
   scripts/motion_planning_python_api_tutorial.py
   scripts/motion_planning_python_api_planning_scene.py

--- a/doc/examples/move_group_interface/CMakeLists.txt
+++ b/doc/examples/move_group_interface/CMakeLists.txt
@@ -1,9 +1,13 @@
+find_package(graph_msgs REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(rviz_visual_tools REQUIRED)
+
 add_executable(move_group_interface_tutorial
     src/move_group_interface_tutorial.cpp)
 target_include_directories(move_group_interface_tutorial
     PUBLIC include)
-ament_target_dependencies(move_group_interface_tutorial
-    ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(move_group_interface_tutorial PUBLIC  moveit_ros_move_group::moveit_move_group_capabilities_base
+moveit_ros_planning_interface::moveit_move_group_interface moveit_visual_tools::moveit_visual_tools)
 
 install(TARGETS move_group_interface_tutorial
   DESTINATION lib/${PROJECT_NAME}

--- a/doc/examples/moveit_cpp/CMakeLists.txt
+++ b/doc/examples/moveit_cpp/CMakeLists.txt
@@ -1,6 +1,10 @@
+find_package(graph_msgs REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(rviz_visual_tools REQUIRED)
+
 add_executable(moveit_cpp_tutorial src/moveit_cpp_tutorial.cpp)
 target_include_directories(moveit_cpp_tutorial PUBLIC include)
-ament_target_dependencies(moveit_cpp_tutorial  ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(moveit_cpp_tutorial PUBLIC rclcpp::rclcpp moveit_ros_planning::moveit_cpp moveit_visual_tools::moveit_visual_tools)
 
 install(TARGETS moveit_cpp_tutorial
   DESTINATION lib/${PROJECT_NAME}

--- a/doc/examples/ompl_interface/ompl_interface_tutorial.rst
+++ b/doc/examples/ompl_interface/ompl_interface_tutorial.rst
@@ -133,7 +133,7 @@ You can adjust the amount of time MoveIt spends on smoothing by increasing the p
 
 Although not currently exposed at the top levels of MoveIt (TODO), more smoothing can be accomplished by setting the simplification duration to 0 (unlimited) in ``model_based_planning_context.cpp``. This will enable OMPL's ``simplifyMax()`` function.
 
-Besides the internal OMPL smoothers, recent efforts have been made to do post-proccessing with STOMP/CHOMP. See `this blog post <http://moveit.ros.org/moveit!/ros/2018/10/25/gsoc-motion-planning-support.html>`_.
+Besides the internal OMPL smoothers, recent efforts have been made to do post-proccessing with STOMP/CHOMP. See `this blog post <https://moveit.picknik.ai/main/doc/concepts/motion_planning.html#>`_.
 
 Persistent Roadmaps
 -------------------

--- a/doc/examples/planning_adapters/planning_adapters_tutorial.rst
+++ b/doc/examples/planning_adapters/planning_adapters_tutorial.rst
@@ -26,7 +26,7 @@ As you add and remove packages from your workspace you will need to clean your w
   cd ~/ws_moveit/src
   catkin clean
 
-Now follow the instructions on the MoveIt homepage for `installing MoveIt Melodic from source <http://moveit.ros.org/install/source/>`_. Note that you can skip the **Prerequisites** section since you should already have a Catkin workspace.
+Now follow the instructions on the MoveIt homepage for `installing MoveIt Humble/jazzy/rolling from source <https://moveit.picknik.ai/main/doc/tutorials/getting_started/getting_started.html>`_. Note that you can skip the **Prerequisites** section since you should already have a Catkin workspace.
 
 Re-source the setup files: ::
 

--- a/doc/examples/planning_scene/CMakeLists.txt
+++ b/doc/examples/planning_scene/CMakeLists.txt
@@ -2,8 +2,7 @@ add_executable(planning_scene_tutorial
     src/planning_scene_tutorial.cpp)
 target_include_directories(planning_scene_tutorial
     PUBLIC include)
-ament_target_dependencies(planning_scene_tutorial
-    ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(planning_scene_tutorial PUBLIC rclcpp::rclcpp moveit_ros_planning::moveit_robot_model_loader)
 
 install(TARGETS planning_scene_tutorial
     DESTINATION lib/${PROJECT_NAME}

--- a/doc/examples/planning_scene_ros_api/CMakeLists.txt
+++ b/doc/examples/planning_scene_ros_api/CMakeLists.txt
@@ -1,9 +1,14 @@
+find_package(graph_msgs REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(rviz_visual_tools REQUIRED)
+
 add_executable(planning_scene_ros_api_tutorial
     src/planning_scene_ros_api_tutorial.cpp)
 target_include_directories(planning_scene_ros_api_tutorial
     PUBLIC include)
-ament_target_dependencies(planning_scene_ros_api_tutorial
-    ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+
+target_link_libraries(planning_scene_ros_api_tutorial PRIVATE  rclcpp::rclcpp   moveit_msgs::moveit_msgs__rosidl_typesupport_cpp rviz_visual_tools::rviz_visual_tools
+ moveit_core::moveit_planning_scene moveit_ros_planning::moveit_robot_model_loader ${geometry_msgs_TARGETS} moveit_visual_tools::moveit_visual_tools)
 
 install(TARGETS planning_scene_ros_api_tutorial
     DESTINATION lib/${PROJECT_NAME}

--- a/doc/examples/realtime_servo/CMakeLists.txt
+++ b/doc/examples/realtime_servo/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(rviz_visual_tools REQUIRED)
 add_executable(pose_tracking_tutorial src/pose_tracking_tutorial.cpp)
 target_include_directories(pose_tracking_tutorial PUBLIC include)
 target_link_libraries(pose_tracking_tutorial PUBLIC
-      ${graph_msgs_TARGETS} ${moveit_servo_TARGETS} tf2_eigen::tf2_eigen
+      ${graph_msgs_TARGETS} moveit_servo::moveit_servo_lib_cpp moveit_servo::moveit_servo_lib_ros tf2_eigen::tf2_eigen
       moveit_ros_planning::moveit_planning_scene_monitor
        rviz_visual_tools::rviz_visual_tools
 )

--- a/doc/examples/realtime_servo/CMakeLists.txt
+++ b/doc/examples/realtime_servo/CMakeLists.txt
@@ -1,6 +1,17 @@
+find_package(graph_msgs REQUIRED)
+find_package(moveit_ros_planning REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(moveit_ros_planning REQUIRED)
+find_package(moveit_servo REQUIRED)
+find_package(rviz_visual_tools REQUIRED)
+
 add_executable(pose_tracking_tutorial src/pose_tracking_tutorial.cpp)
 target_include_directories(pose_tracking_tutorial PUBLIC include)
-ament_target_dependencies(pose_tracking_tutorial  ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(pose_tracking_tutorial PUBLIC
+      ${graph_msgs_TARGETS} ${moveit_servo_TARGETS} tf2_eigen::tf2_eigen
+      moveit_ros_planning::moveit_planning_scene_monitor
+       rviz_visual_tools::rviz_visual_tools
+)
 
 install(
   TARGETS

--- a/doc/examples/realtime_servo/src/pose_tracking_tutorial.cpp
+++ b/doc/examples/realtime_servo/src/pose_tracking_tutorial.cpp
@@ -119,7 +119,7 @@ private:
 
   rclcpp::Node::SharedPtr node_;
   Eigen::Vector3d hinge_, center_, dims_;
-  double angle_, step_, rotation_radius_;
+  double angle_, rotation_radius_;
   rclcpp::Publisher<moveit_msgs::msg::PlanningScene>::SharedPtr collision_object_publisher_;
   moveit_msgs::msg::CollisionObject collision_object_;
   shape_msgs::msg::SolidPrimitive door_primitive_;

--- a/doc/examples/robot_model_and_robot_state/CMakeLists.txt
+++ b/doc/examples/robot_model_and_robot_state/CMakeLists.txt
@@ -2,8 +2,7 @@ add_executable(robot_model_and_robot_state_tutorial
     src/robot_model_and_robot_state_tutorial.cpp)
 target_include_directories(robot_model_and_robot_state_tutorial
     PUBLIC include)
-ament_target_dependencies(robot_model_and_robot_state_tutorial
-    ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(robot_model_and_robot_state_tutorial PUBLIC moveit_ros_planning::moveit_robot_model_loader)
 
 install(TARGETS robot_model_and_robot_state_tutorial
     DESTINATION lib/${PROJECT_NAME}

--- a/doc/examples/tests/CMakeLists.txt
+++ b/doc/examples/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(tests_tutorial test/tests.cpp)
   target_link_libraries(tests_tutorial
-    ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+  ${Boost_LIBRARIES})
 endif()

--- a/doc/examples/visualizing_collisions/CMakeLists.txt
+++ b/doc/examples/visualizing_collisions/CMakeLists.txt
@@ -5,13 +5,5 @@ add_executable(visualizing_collisions_tutorial
 target_link_libraries(visualizing_collisions_tutorial
   ${interactive_markers_LIBRARIES}
   interactivity_utils
-  ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
 )
-
-install(
-  TARGETS
-  visualizing_collisions_tutorial
-  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-
-install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/doc/how_to_guides/kinematics_cost_function/CMakeLists.txt
+++ b/doc/how_to_guides/kinematics_cost_function/CMakeLists.txt
@@ -1,9 +1,14 @@
+find_package(graph_msgs REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(rviz_visual_tools REQUIRED)
+
 add_executable(kinematics_cost_function_tutorial
     src/kinematics_cost_function_tutorial.cpp)
 target_include_directories(kinematics_cost_function_tutorial
     PUBLIC include)
-ament_target_dependencies(kinematics_cost_function_tutorial
-    ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+target_link_libraries(kinematics_cost_function_tutorial PUBLIC moveit_ros_move_group::moveit_move_group_capabilities_base
+moveit_ros_planning_interface::moveit_move_group_interface moveit_visual_tools::moveit_visual_tools)
 
 install(TARGETS kinematics_cost_function_tutorial
   DESTINATION lib/${PROJECT_NAME}

--- a/doc/how_to_guides/parallel_planning/CMakeLists.txt
+++ b/doc/how_to_guides/parallel_planning/CMakeLists.txt
@@ -1,6 +1,11 @@
+find_package(graph_msgs REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(rviz_visual_tools REQUIRED)
+find_package(OpenSSL REQUIRED)
+
 add_executable(parallel_planning_example src/parallel_planning_main.cpp)
 target_include_directories(parallel_planning_example PRIVATE include)
-ament_target_dependencies(parallel_planning_example  ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(parallel_planning_example PUBLIC rclcpp::rclcpp  moveit_ros_planning::moveit_cpp moveit_visual_tools::moveit_visual_tools moveit_ros_warehouse::moveit_warehouse)
 
 install(TARGETS parallel_planning_example
   DESTINATION lib/${PROJECT_NAME}

--- a/doc/how_to_guides/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/doc/how_to_guides/pilz_industrial_motion_planner/CMakeLists.txt
@@ -1,14 +1,19 @@
+find_package(graph_msgs REQUIRED)
+find_package(moveit_task_constructor_core REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(rviz_visual_tools REQUIRED)
+
 add_executable(pilz_move_group src/pilz_move_group.cpp)
 target_include_directories(pilz_move_group PUBLIC include)
-ament_target_dependencies(pilz_move_group ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(pilz_move_group PUBLIC ${moveit_task_constructor_core_TARGETS} rclcpp::rclcpp rclcpp_action::rclcpp_action moveit_ros_planning_interface::moveit_move_group_interface moveit_visual_tools::moveit_visual_tools)
 
 add_executable(pilz_mtc src/pilz_mtc.cpp)
 target_include_directories(pilz_mtc PUBLIC include)
-ament_target_dependencies(pilz_mtc ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(pilz_mtc PUBLIC rclcpp::rclcpp rclcpp_action::rclcpp_action moveit_ros_planning_interface::moveit_move_group_interface moveit_visual_tools::moveit_visual_tools ${moveit_task_constructor_core_TARGETS})
 
 add_executable(pilz_sequence src/pilz_sequence.cpp)
 target_include_directories(pilz_sequence PUBLIC include)
-ament_target_dependencies(pilz_sequence ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(pilz_sequence PUBLIC rclcpp::rclcpp rclcpp_action::rclcpp_action moveit_ros_planning_interface::moveit_move_group_interface moveit_visual_tools::moveit_visual_tools)
 
 install(
   TARGETS

--- a/doc/how_to_guides/pilz_industrial_motion_planner/CMakeLists.txt
+++ b/doc/how_to_guides/pilz_industrial_motion_planner/CMakeLists.txt
@@ -5,11 +5,11 @@ find_package(rviz_visual_tools REQUIRED)
 
 add_executable(pilz_move_group src/pilz_move_group.cpp)
 target_include_directories(pilz_move_group PUBLIC include)
-target_link_libraries(pilz_move_group PUBLIC ${moveit_task_constructor_core_TARGETS} rclcpp::rclcpp rclcpp_action::rclcpp_action moveit_ros_planning_interface::moveit_move_group_interface moveit_visual_tools::moveit_visual_tools)
+target_link_libraries(pilz_move_group PUBLIC moveit_task_constructor_core::moveit_task_constructor_core moveit_task_constructor_core::moveit_task_constructor_core_stages rclcpp::rclcpp rclcpp_action::rclcpp_action moveit_ros_planning_interface::moveit_move_group_interface moveit_visual_tools::moveit_visual_tools)
 
 add_executable(pilz_mtc src/pilz_mtc.cpp)
 target_include_directories(pilz_mtc PUBLIC include)
-target_link_libraries(pilz_mtc PUBLIC rclcpp::rclcpp rclcpp_action::rclcpp_action moveit_ros_planning_interface::moveit_move_group_interface moveit_visual_tools::moveit_visual_tools ${moveit_task_constructor_core_TARGETS})
+target_link_libraries(pilz_mtc PUBLIC rclcpp::rclcpp rclcpp_action::rclcpp_action moveit_ros_planning_interface::moveit_move_group_interface moveit_visual_tools::moveit_visual_tools moveit_task_constructor_core::moveit_task_constructor_core moveit_task_constructor_core::moveit_task_constructor_core_stages)
 
 add_executable(pilz_sequence src/pilz_sequence.cpp)
 target_include_directories(pilz_sequence PUBLIC include)

--- a/doc/how_to_guides/trajectory_cache/CMakeLists.txt
+++ b/doc/how_to_guides/trajectory_cache/CMakeLists.txt
@@ -1,5 +1,14 @@
+find_package(graph_msgs REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(rviz_visual_tools REQUIRED)
+find_package(OpenSSL REQUIRED)
+
 add_executable(trajectory_cache_demo src/trajectory_cache_demo.cpp)
-ament_target_dependencies(trajectory_cache_demo ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost moveit_ros_trajectory_cache)
+target_link_libraries(trajectory_cache_demo PUBLIC moveit_ros_planning_interface::moveit_move_group_interface
+
+moveit_ros_trajectory_cache::moveit_ros_trajectory_cache_utils_lib moveit_ros_trajectory_cache::moveit_ros_trajectory_cache_features_lib moveit_ros_trajectory_cache::moveit_ros_trajectory_cache_cache_insert_policies_lib moveit_ros_trajectory_cache::moveit_ros_trajectory_cache_lib
+
+moveit_visual_tools::moveit_visual_tools)
 
 install(TARGETS trajectory_cache_demo DESTINATION lib/${PROJECT_NAME})
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})

--- a/doc/how_to_guides/using_ompl_constrained_planning/CMakeLists.txt
+++ b/doc/how_to_guides/using_ompl_constrained_planning/CMakeLists.txt
@@ -1,9 +1,13 @@
+find_package(graph_msgs REQUIRED)
+find_package(moveit_visual_tools REQUIRED)
+find_package(rviz_visual_tools REQUIRED)
 add_executable(ompl_constrained_planning
     src/ompl_constrained_planning_tutorial.cpp)
 target_include_directories(ompl_constrained_planning
     PUBLIC include)
-ament_target_dependencies(ompl_constrained_planning
-    ${THIS_PACKAGE_INCLUDE_DEPENDS} Boost)
+target_link_libraries(ompl_constrained_planning PUBLIC
+${graph_msgs_TARGETS}
+moveit_ros_move_group::moveit_move_group_capabilities_base moveit_ros_planning_interface::moveit_move_group_interface moveit_visual_tools::moveit_visual_tools )
 
 install(TARGETS ompl_constrained_planning
   DESTINATION lib/${PROJECT_NAME}

--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/CMakeLists.txt
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/CMakeLists.txt
@@ -1,8 +1,22 @@
+find_package(moveit_ros_planning REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(moveit_task_constructor_core REQUIRED)
+
 add_executable(mtc_tutorial src/mtc_node.cpp)
-ament_target_dependencies(mtc_tutorial ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  target_link_libraries(mtc_tutorial PUBLIC rclcpp::rclcpp moveit_core::moveit_planning_interface moveit_core::moveit_planning_scene
+  moveit_ros_planning::moveit_planning_pipeline
+        moveit_ros_planning::moveit_planning_pipeline_interfaces
+        moveit_ros_planning::moveit_planning_scene_monitor
+        moveit_ros_planning_interface::moveit_move_group_interface
+        ${moveit_task_constructor_core_TARGETS})
 
 add_executable(minimal_mtc_tutorial src/minimal.cpp)
-ament_target_dependencies(minimal_mtc_tutorial ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  target_link_libraries(minimal_mtc_tutorial PUBLIC rclcpp::rclcpp moveit_core::moveit_planning_interface moveit_core::moveit_planning_scene
+  moveit_ros_planning::moveit_planning_pipeline
+        moveit_ros_planning::moveit_planning_pipeline_interfaces
+        moveit_ros_planning::moveit_planning_scene_monitor
+        moveit_ros_planning_interface::moveit_move_group_interface
+        ${moveit_task_constructor_core_TARGETS})
 
 install(TARGETS mtc_tutorial minimal_mtc_tutorial
         ARCHIVE DESTINATION lib

--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/CMakeLists.txt
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/CMakeLists.txt
@@ -8,7 +8,8 @@ add_executable(mtc_tutorial src/mtc_node.cpp)
         moveit_ros_planning::moveit_planning_pipeline_interfaces
         moveit_ros_planning::moveit_planning_scene_monitor
         moveit_ros_planning_interface::moveit_move_group_interface
-        ${moveit_task_constructor_core_TARGETS})
+        moveit_task_constructor_core::moveit_task_constructor_core
+        moveit_task_constructor_core::moveit_task_constructor_core_stages)
 
 add_executable(minimal_mtc_tutorial src/minimal.cpp)
   target_link_libraries(minimal_mtc_tutorial PUBLIC rclcpp::rclcpp moveit_core::moveit_planning_interface moveit_core::moveit_planning_scene
@@ -16,7 +17,8 @@ add_executable(minimal_mtc_tutorial src/minimal.cpp)
         moveit_ros_planning::moveit_planning_pipeline_interfaces
         moveit_ros_planning::moveit_planning_scene_monitor
         moveit_ros_planning_interface::moveit_move_group_interface
-        ${moveit_task_constructor_core_TARGETS})
+        moveit_task_constructor_core::moveit_task_constructor_core
+        moveit_task_constructor_core::moveit_task_constructor_core_stages)
 
 install(TARGETS mtc_tutorial minimal_mtc_tutorial
         ARCHIVE DESTINATION lib

--- a/doc/tutorials/quickstart_in_rviz/CMakeLists.txt
+++ b/doc/tutorials/quickstart_in_rviz/CMakeLists.txt
@@ -4,15 +4,18 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ros_testing REQUIRED)
+  find_package(control_msgs REQUIRED)
   find_package(Boost REQUIRED COMPONENTS filesystem)
 
   # Run all lint tests in package.xml
   ament_lint_auto_find_test_dependencies()
 
+
   # Basic "quickstart_in_rviz" bringup test
   ament_add_gtest_executable(bringup_test
     test/bringup_test.cpp
   )
-  ament_target_dependencies(bringup_test ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  target_link_libraries(bringup_test ${control_msgs_TARGETS} ${moveit_msgs_TARGETS}
+                          rclcpp::rclcpp rclcpp_action::rclcpp_action)
   add_ros_test(test/bringup_test.test.py TIMEOUT 120 ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
 endif()

--- a/doc/tutorials/quickstart_in_rviz/test/bringup_test.cpp
+++ b/doc/tutorials/quickstart_in_rviz/test/bringup_test.cpp
@@ -5,7 +5,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 
-#include <chrono>
 #include <future>
 #include <gtest/gtest.h>
 #include <stdlib.h>

--- a/doc/tutorials/visualizing_in_rviz/visualizing_in_rviz.rst
+++ b/doc/tutorials/visualizing_in_rviz/visualizing_in_rviz.rst
@@ -27,11 +27,11 @@ Then in your ``CMakeLists.txt`` add this line to the section of ``find_package``
 
   find_package(moveit_visual_tools REQUIRED)
 
-Further down in the file extend the ``ament_target_dependencies`` macro call to include the new dependency like this:
+Further down in the file extend the ``target_link_libraries`` macro call to include the new dependency like this:
 
 .. code-block:: cmake
 
-  ament_target_dependencies(
+  target_link_libraries(
     hello_moveit
     "moveit_ros_planning_interface"
     "moveit_visual_tools"

--- a/index.rst
+++ b/index.rst
@@ -6,7 +6,7 @@ Welcome to the unified MoveIt documentation, which includes tutorials, how-to gu
 MoveIt 2 is the robotic manipulation platform for ROS 2 and incorporates the latest advances in motion planning, manipulation, 3D perception, kinematics, control, and navigation. MoveIt 2 was first released in 2019; for ROS 1 documentation, see `MoveIt 1 tutorials <https://moveit.github.io/moveit_tutorials>`_.
 For the commercially supported version see `MoveIt Pro tutorials <https://docs.picknik.ai/en/stable/>`_.
 
-.. image:: http://moveit.ros.org/assets/images/roadmap.png
+.. image:: https://moveit.ai/assets/logo/moveit_logo-white.png
    :width: 400px
 
 How-To Use This Website
@@ -42,5 +42,5 @@ Help us improve these docs and we'll be happy to include you here also!
 Corporate Sponsorship
 ---------------------
 
-* The tutorials had a major update in 2018 during a code sprint sponsored by Franka Emika in collaboration with `PickNik Robotics <https://picknik.ai/>`_ (`Check out the blog post! <http://moveit.ros.org/moveit!/ros/2018/02/26/tutorials-documentation-codesprint.html>`_)
+* The tutorials had a major update in 2018 during a code sprint sponsored by Franka Emika in collaboration with `PickNik Robotics <https://picknik.ai/>`_ (`Check out the blog post! <https://moveit.ai/moveit!/ros/2018/02/26/tutorials-documentation-codesprint.html>`_)
 * The tutorials had another major update in 2022 during a doc-a-thon sponsored by `PickNik Robotics <https://picknik.ai/>`_.


### PR DESCRIPTION
### Aimed issues

- [ ] The issue [discourse.openrobotics.org/43938](https://discourse.openrobotics.org/t/best-practices-for-replacing-ament-target-dependencies-in-kilted-while-maintaining-compatibility/43938) has been affecting moveit2_tutorials as well.
- [ ] Failing CI https://github.com/moveit/moveit2_tutorials/issues/1102

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] While waiting for someone to review your request --> Large part of this PR is taken from, and on 2025/01/08 https://github.com/moveit/moveit2_tutorials/pull/1072#pullrequestreview-3635667391 is was already approved. Since then, there's only 1 commit added that is aimed to resolve the final failing CI job.

### For the reviewers
- Recommend to squash (there are many similar commits)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated links to current MoveIt documentation, tutorials, robot listings, and secure HTTPS URLs.
  - Refreshed installation guidance for Humble, Jazzy, and Rolling.
  - Updated RViz instructions for current build and linking practices.

- **Build & Compatibility**
  - Improved dependency setup and compilation across Jazzy and Rolling environments.
  - Added broader validation for supported ROS 2 configurations.

- **Quality**
  - Enhanced formatting, caching, validation, and deployment workflows.
  - Added automatic patch capture when formatting checks detect changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->