### PR TITLE
Clarify on not cancelling executor in MTC tutorial (#1105)

### DIFF
--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
@@ -487,7 +487,10 @@ We return the task and finish with the ``createTask()`` function.
       return task;
     }
 
-Finally, we have ``main``: the following lines create a node using the class defined above, and calls the class methods to set up and execute a basic MTC task. In this example, we do not cancel the executor once the task has finished executing to keep the node alive to inspect the solutions in RViz.
+Finally, we have ``main``: the following lines create a node using the class defined above, and calls the class methods to set up and execute a basic MTC task. 
+In this example, we do not cancel the executor once the task has finished executing to keep the program running to inspect the solutions in RViz. 
+Note that it's the internal executor and node inside ``task_.introspection()`` that responds to RViz's introspect request when you click on the solutions in Task Tree, in RViz. 
+The sole purpose of not cancelling the executor is simply, not letting the program to quit until you CTRL-C on it. 
 
 .. code-block:: c++
 

--- a/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
+++ b/doc/tutorials/pick_and_place_with_moveit_task_constructor/pick_and_place_with_moveit_task_constructor.rst
@@ -488,9 +488,9 @@ We return the task and finish with the ``createTask()`` function.
     }
 
 Finally, we have ``main``: the following lines create a node using the class defined above, and calls the class methods to set up and execute a basic MTC task. 
-In this example, we do not cancel the executor once the task has finished executing to keep the program running to inspect the solutions in RViz. 
-Note that it's the internal executor and node inside ``task_.introspection()`` that responds to RViz's introspect request when you click on the solutions in Task Tree, in RViz. 
-The sole purpose of not cancelling the executor is simply, not letting the program to quit until you CTRL-C on it. 
+In this example, we do not cancel the executor once the task has finished executing to keep the program running and thus to allow inspection of the solutions in RViz. 
+Note that RViz only lazily caches submitted solutions. If you click on not yet viewed solutions in RViz' MTC Task Tree, RViz requests the solution information from the planning program. (Actually, it's the executor and node owned by the task's `Introspection` instance that respond to those requests.)
+Thus, by keeping the program alive, one can inspect all solution in peace. The program will quit if you CTRL-C it. 
 
 .. code-block:: c++
 


### PR DESCRIPTION
### Description

Fixes #1105

Add clarification on why we don't cancel the executor after task finish in MTC tutorial. 

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Corrected the MoveIt Task Constructor pick-and-place tutorial to initialize the grasp-frame transform before applying orientation and translation adjustments.
  - Expanded guidance on node and task setup.
  - Explained executor behavior, RViz solution caching and introspection, and how to terminate the program with Ctrl-C.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->