### PR TITLE
Revert #1091 "Update link outdate"

### DIFF
--- a/doc/tutorials/your_first_project/your_first_project.rst
+++ b/doc/tutorials/your_first_project/your_first_project.rst
@@ -268,7 +268,7 @@ Summary
 
 * You created a ROS 2 package and wrote your first program using MoveIt.
 * You learned about using the MoveGroupInterface to plan and execute moves.
-* :codedir:`Here is a copy of the full hello_moveit.cpp source at the end of this tutorial<tutorials/your_first_project/panda_hello_moveit.cpp>`.
+* :codedir:`Here is a copy of the full hello_moveit.cpp source at the end of this tutorial<tutorials/your_first_project/kinova_hello_moveit.cpp>`.
 
 Further Reading
 ---------------


### PR DESCRIPTION
Reverts moveit/moveit2_tutorials#1091 for the following reasons. In a nutshell I noticed I might have merged that  PR prematurely:
- in moveit2_tutorials, kinova and panda are used extensively. I figured out kinova is preferred under `doc/tutorials` while only panda is in `doc/examples`.
- The merged change in #1091, which switches kinova to panda, is under `doc/tutorials` where kinova should be preferred over panda as mentioned above.
   - In my previous review https://github.com/moveit/moveit2_tutorials/pull/1091#discussion_r3337903076 I didn't dig enough to find this preference.
- Btw, in its original state, #1091 was targeted against `humble` branch. So an issue still remains on `humble` branch. That's a separate problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the first-project tutorial to link to the correct Kinova example source file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->