### PR TITLE
fix apt-key deprecation in Dockerfile

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -49,8 +49,8 @@ COPY ./doc/tutorials/pick_and_place_with_moveit_task_constructor/src/mtc_node.cp
 COPY ./doc/tutorials/pick_and_place_with_moveit_task_constructor/launch src/mtc_tutorial/launch
 
 # Install Gazebo, which is needed by some dependencies.
-RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' && \
-    wget http://packages.osrfoundation.org/gazebo.key -O - | sudo gpg --dearmor -o /usr/share/keyrings/perforce-archive-keyring.gpg && \
+RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" > /etc/apt/sources.list.d/gazebo-stable.list && \
     sudo apt update && \
     sudo apt-get install -y "gz-${GZ_VERSION}"
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -50,7 +50,7 @@ COPY ./doc/tutorials/pick_and_place_with_moveit_task_constructor/launch src/mtc_
 
 # Install Gazebo, which is needed by some dependencies.
 RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' && \
-    wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add - && \
+    wget http://packages.osrfoundation.org/gazebo.key -O - | sudo gpg --dearmor -o /usr/share/keyrings/perforce-archive-keyring.gpg && \
     sudo apt update && \
     sudo apt-get install -y "gz-${GZ_VERSION}"
 


### PR DESCRIPTION
### Description

fix apt-key deprecation in Dockerfile

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/moveit/moveit2/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Gazebo repository key handling to use a modern, more secure package-signing method during container setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->